### PR TITLE
Add tensorflow support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 ## Prune and Quantize ML models
 PQuant is a library for training compressed machine learning models, developed at CERN as part of the [Next Generation Triggers](https://nextgentriggers.web.cern.ch/t13/) project.
 
-PQuant replaces the layers and activations it finds with a Compressed (in the case of layers) or Quantized (in the case of activations) variant. These automatically handle the quantization of the weights, biases and activations, and the pruning of the weights.
+PQuant replaces the layers and activations it finds with a Compressed (in the case of layers) or Quantized (in the case of activations) variant. These automatically handle the quantization of the weights, biases and activations, and the pruning of the weights. 
+Both PyTorch and TensorFlow models are supported. 
+
+Layers that can be compressed: Conv2D and Linear layers, Tanh and ReLU activations for both TensorFlow and PyTorch. For PyTorch, also Conv1D.
 
 ![alt text](docs/_static/pquant_transform.png)
 
@@ -13,11 +16,11 @@ The various pruning methods have different training steps, such as a pre-trainin
 
 ### Example
 Example notebook can be found [here](https://github.com/nroope/PQuant/tree/main/examples). It handles the
-    1. Creation of a torch model and data loaders.
-    2. Creation of the training and validation functions.
-    3. Loading a default pruning configuration of a pruning method.
-    4. Using the configuration, the model, and the training and validation functions, call the training function of PQuant to train and compress the model.
-    5. Creating a custom quantization and pruning configuration for a given model (disable pruning for some layers, different quantization bitwidths for different layers).
+  1. Creation of a torch model and data loaders.
+  2. Creation of the training and validation functions.
+  3. Loading a default pruning configuration of a pruning method.
+  4. Using the configuration, the model, and the training and validation functions, call the training function of PQuant to train and compress the model.
+  5. Creating a custom quantization and pruning configuration for a given model (disable pruning for some layers, different quantization bitwidths for different layers).
 
 ### Pruning methods
 A description of the pruning methods and their hyperparameters can be found [here](docs/pruning_methods.md).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![alt text](docs/_static/pquant.png)
 
 ## Prune and Quantize ML models
-PQuant is a library for training compressed machine learning models. It allows the user to define their model using the typical PyTorch layers and activations, such as nn.Linear and nn.ReLU(), and train the model while quantizing and pruning it.
+PQuant is a library for training compressed machine learning models, developed at CERN as part of the [Next Generation Triggers](https://nextgentriggers.web.cern.ch/t13/) project.
 
 PQuant replaces the layers and activations it finds with a Compressed (in the case of layers) or Quantized (in the case of activations) variant. These automatically handle the quantization of the weights, biases and activations, and the pruning of the weights.
 
@@ -27,3 +27,10 @@ A description of the pruning methods and their hyperparameters can be found [her
 
 ```pip install .``` for regular install, ```pip install -e .``` if you wish to install as a local editable package
 To run the code, [HGQ2](https://github.com/calad0i/HGQ2) is also needed. For now it only has local install available, so download the repository and install it locally.
+
+### Authors
+ - Roope Niemi (CERN)
+ - Anastasiia Petrovych (CERN)
+ - Chang Sun (Caltech)
+ - Michael Kagan (SLAC National Accelerator Laboratory)
+ - Vladimir Loncar (CERN)

--- a/docs/pruning_methods.md
+++ b/docs/pruning_methods.md
@@ -9,6 +9,7 @@ Collect layer outputs to calculate average layer activity (how often layer neuro
 - `threshold`: If a neuron or channel is less active than this threshold, prune it.
 - `threshold_decay`: Not used.
 - `t_delta`: How many batches to collect as calibration data.
+- `t_start_collecting_batch`: At which epoch during training the collection begins
 
 #### [AutoSparse](https://arxiv.org/abs/2304.06941)
 $x = sign(W) \cdot ReLU(|W| - \sigma(T))$.

--- a/docs/pruning_methods.md
+++ b/docs/pruning_methods.md
@@ -2,7 +2,7 @@
 
 Our implementations follow the actual implementations of the author's of the papers, whenever we were able to find one. Because of this some of the functionality of the pruning methods can differ slightly from the equations shown in the papers.
 
-#### [Activation pruning (continual learning)](https://arxiv.org/abs/1903.04476)
+#### [Activation pruning](https://arxiv.org/abs/1903.04476)
 Collect layer outputs to calculate average layer activity (how often layer neuron / channel outputs values greater than 0). Prune those neurons and channels which have smaller activity value than a given threshold.
 
 **Hyperparameters**
@@ -33,7 +33,7 @@ A multi-round pruning algorithm.
 ```math
  x = W\cdot M
 ```
-where 
+where
 ```math
 M=(\frac{\sigma(\beta s)}{\sigma(s_{init})})
 ```

--- a/examples/example_prune_quantize_resnet.ipynb
+++ b/examples/example_prune_quantize_resnet.ipynb
@@ -85,9 +85,9 @@
    "outputs": [],
    "source": [
     "# Replace layers with compressed layers\n",
-    "from pquant import add_pruning_and_quantization\n",
+    "from pquant import add_compression_layers\n",
     "input_shape = (256,3,32,32)\n",
-    "model = add_pruning_and_quantization(model, config, input_shape)\n",
+    "model = add_compression_layers(model, config, input_shape)\n",
     "model"
    ]
   },
@@ -365,7 +365,7 @@
     "\n",
     "\n",
     "from pquant import add_default_layer_quantization_pruning_to_config\n",
-    "config = add_default_layer_quantization_pruning_to_config(config, model)\n",
+    "config = add_default_layer_quantization_pruning_to_config(model, config)\n",
     "config"
    ]
   },

--- a/src/pquant/__init__.py
+++ b/src/pquant/__init__.py
@@ -1,18 +1,17 @@
 from . import configs, pruning_methods
 from .core.compressed_layers import (
+    add_compression_layers,
     add_default_layer_quantization_pruning_to_config,
-    add_pruning_and_quantization,
     get_layer_keep_ratio,
     get_model_losses,
     remove_pruning_from_model,
 )
-from .core.p_optim import pAdam, pSGD
 from .core.train import iterative_train
 from .core.utils import get_default_config
 
 __all__ = [
     "iterative_train",
-    "add_pruning_and_quantization",
+    "add_compression_layers",
     "remove_pruning_from_model",
     "get_model_losses",
     "get_default_config",

--- a/src/pquant/configs/config_ap.yaml
+++ b/src/pquant/configs/config_ap.yaml
@@ -5,7 +5,8 @@ pruning_parameters:
   pruning_method: activation_pruning
   threshold: 0.3
   threshold_decay: 0.
-  t_delta: 20
+  t_delta: 50
+  t_start_collecting_batch: 50
 quantization_parameters:
   default_integer_bits: 0.
   default_fractional_bits: 7.
@@ -18,7 +19,7 @@ quantization_parameters:
 training_parameters:
   epochs: 100
   fine_tuning_epochs: 0
-  pretraining_epochs: 50
+  pretraining_epochs: 0
   pruning_first: false
   rewind: never
   rounds: 1

--- a/src/pquant/configs/config_ap.yaml
+++ b/src/pquant/configs/config_ap.yaml
@@ -2,7 +2,7 @@ pruning_parameters:
   disable_pruning_for_layers: # Disable pruning for these layers, even if enable_pruning is true
     -
   enable_pruning: true
-  pruning_method: continual_learning
+  pruning_method: activation_pruning
   threshold: 0.3
   threshold_decay: 0.
   t_delta: 20

--- a/src/pquant/configs/config_wanda.yaml
+++ b/src/pquant/configs/config_wanda.yaml
@@ -8,7 +8,7 @@ pruning_parameters:
   threshold_decay: 0.
   sparsity: 0.90
   t_delta: 100
-  t_start_collecting: 10000
+  t_start_collecting_batch: 100
 quantization_parameters:
   default_integer_bits: 0.
   default_fractional_bits: 7.
@@ -26,7 +26,7 @@ training_parameters:
   rewind: never
   rounds: 1
   save_weights_epoch: -1
-batch_size: 256
+batch_size: 64
 cosine_tmax: 200
 gamma: 0.1
 l2_decay: 0.0001

--- a/src/pquant/core/compressed_layers.py
+++ b/src/pquant/core/compressed_layers.py
@@ -7,13 +7,13 @@ def add_default_layer_quantization_pruning_to_config(model, config):
             add_default_layer_quantization_pruning_to_config_torch,
         )
 
-        return add_default_layer_quantization_pruning_to_config_torch(config, model)
+        return add_default_layer_quantization_pruning_to_config_torch(model, config)
     else:
         from pquant.core.tf_impl.compressed_layers_tf import (
             add_default_layer_quantization_pruning_to_config_tf,
         )
 
-        return add_default_layer_quantization_pruning_to_config_tf(config, model)
+        return add_default_layer_quantization_pruning_to_config_tf(model, config)
 
 
 def add_compression_layers(model, config, input_shape):

--- a/src/pquant/core/compressed_layers.py
+++ b/src/pquant/core/compressed_layers.py
@@ -1,654 +1,70 @@
-import torch
-import torch.nn as nn
-import torch.nn.functional as F
-from hgq.quantizer import Quantizer
-from quantizers import get_fixed_quantizer
-from torch.fx import symbolic_trace
-
-from pquant.core.activations_quantizer import QuantizedReLU, QuantizedTanh
-from pquant.core.utils import get_pruning_layer
+import keras
 
 
-class CompressedLayerLinear(nn.Module):
-    def __init__(self, config, layer):
-        super().__init__()
-        self.f_weight = torch.tensor(config["quantization_parameters"]["default_fractional_bits"])
-        self.i_weight = torch.tensor(config["quantization_parameters"]["default_integer_bits"])
-        self.f_bias = torch.tensor(config["quantization_parameters"]["default_fractional_bits"])
-        self.i_bias = torch.tensor(config["quantization_parameters"]["default_integer_bits"])
-
-        self.in_features = layer.in_features
-        self.out_features = layer.out_features
-        self.weight = nn.Parameter(layer.weight.clone())
-        self.pruning_layer = get_pruning_layer(config=config, layer=layer, out_size=layer.out_features)
-        self.pruning_method = config["pruning_parameters"]["pruning_method"]
-        overflow = "SAT_SYM" if config["quantization_parameters"]["use_symmetric_quantization"] else "SAT"
-        self.quantizer = get_fixed_quantizer(overflow_mode=overflow)
-        if config["quantization_parameters"]["use_high_granularity_quantization"]:
-            self.hgq_weight = Quantizer(
-                k0=1.0,
-                i0=self.i_weight,
-                f0=self.f_weight,
-                round_mode="RND",
-                overflow_mode=overflow,
-                q_type="kif",
-                homogeneous_axis=(),
-            )
-            self.hgq_weight.build(self.weight.shape)
-            if layer.bias is not None:
-                self.hgq_bias = Quantizer(
-                    k0=1.0,
-                    i0=self.i_bias,
-                    f0=self.f_bias,
-                    round_mode="RND",
-                    overflow_mode=overflow,
-                    q_type="kif",
-                    homogeneous_axis=(),
-                )
-                self.hgq_bias.build(layer.bias.shape)
-            self.hgq_gamma = config["quantization_parameters"]["hgq_gamma"]
-
-        self.bias = nn.Parameter(layer.bias.clone()) if layer.bias is not None else None
-        self.init_weight = self.weight.clone()
-        self.pruning_first = config["training_parameters"]["pruning_first"]
-        self.enable_quantization = config["quantization_parameters"]["enable_quantization"]
-        self.use_high_granularity_quantization = config["quantization_parameters"]["use_high_granularity_quantization"]
-        self.enable_pruning = config["pruning_parameters"]["enable_pruning"]
-
-    def save_weights(self):
-        self.init_weight = self.weight.clone()
-
-    def rewind_weights(self):
-        self.weight.data = self.init_weight.clone()
-
-    def hgq_loss(self):
-        if self.pruning_layer.is_pretraining:
-            return 0.0
-        loss = (torch.sum(self.hgq_weight.quantizer.i) + torch.sum(self.hgq_weight.quantizer.f)) * self.hgq_gamma
-        if self.bias is not None:
-            loss += (torch.sum(self.hgq_bias.quantizer.i) + torch.sum(self.hgq_bias.quantizer.f)) * self.hgq_gamma
-        return loss
-
-    def quantize(self, weight, bias):
-        if self.enable_quantization:
-            if self.use_high_granularity_quantization:
-                weight = self.hgq_weight(weight)
-                bias = None if bias is None else self.hgq_bias(bias)
-            else:
-                weight = self.quantizer(weight, k=torch.tensor(1.0), i=self.i_weight, f=self.f_weight, training=True)
-                bias = (
-                    None
-                    if bias is None
-                    else self.quantizer(bias, k=torch.tensor(1.0), i=self.i_bias, f=self.f_bias, training=True)
-                )
-        return weight, bias
-
-    def prune(self, weight):
-        if self.enable_pruning:
-            weight = self.pruning_layer(weight)
-        return weight
-
-    def prune_and_quantize(self, weight, bias):
-        if self.pruning_first:
-            weight = self.prune(weight)
-            weight, bias = self.quantize(weight, bias)
-        else:
-            weight, bias = self.quantize(weight, bias)
-            weight = self.prune(weight)
-        return weight, bias
-
-    def forward(self, x):
-        weight, bias = self.prune_and_quantize(self.weight, self.bias)
-        if self.pruning_method == "wanda":
-            self.pruning_layer.collect_input(x)
-        x = F.linear(x, weight, bias)
-        if self.pruning_method == "continual_learning":
-            self.pruning_layer.collect_output(x)
-        return x
-
-
-class CompressedLayerConv2d(nn.Module):
-    def __init__(self, config, layer):
-        super().__init__()
-        self.f_weight = torch.tensor(config["quantization_parameters"]["default_fractional_bits"])
-        self.i_weight = torch.tensor(config["quantization_parameters"]["default_integer_bits"])
-        self.f_bias = torch.tensor(config["quantization_parameters"]["default_fractional_bits"])
-        self.i_bias = torch.tensor(config["quantization_parameters"]["default_integer_bits"])
-        self.pruning_layer = get_pruning_layer(config=config, layer=layer, out_size=layer.out_channels)
-        self.pruning_method = config["pruning_parameters"]["pruning_method"]
-        overflow = "SAT_SYM" if config["quantization_parameters"]["use_symmetric_quantization"] else "SAT"
-        self.quantizer = get_fixed_quantizer(overflow_mode=overflow)
-        self.weight = nn.Parameter(layer.weight.clone())
-        self.init_weight = self.weight.clone()
-        if config["quantization_parameters"]["use_high_granularity_quantization"]:
-            self.hgq_weight = Quantizer(
-                k0=1.0,
-                i0=self.i_weight,
-                f0=self.f_weight,
-                round_mode="RND",
-                overflow_mode=overflow,
-                q_type="kif",
-                homogeneous_axis=(),
-            )
-            self.hgq_weight.build(self.weight.shape)
-            if layer.bias is not None:
-                self.hgq_bias = Quantizer(
-                    k0=1.0,
-                    i0=self.i_bias,
-                    f0=self.f_bias,
-                    round_mode="RND",
-                    overflow_mode=overflow,
-                    q_type="kif",
-                    homogeneous_axis=(),
-                )
-                self.hgq_bias.build(layer.bias.shape)
-            self.hgq_gamma = config["quantization_parameters"]["hgq_gamma"]
-
-        self.bias = nn.Parameter(layer.bias.clone()) if layer.bias is not None else None
-        self.stride = layer.stride
-        self.dilation = layer.dilation
-        self.padding = layer.padding
-        self.groups = layer.groups
-        self.in_channels = layer.in_channels
-        self.out_channels = layer.out_channels
-        self.kernel_size = layer.kernel_size
-        self.padding_mode = layer.padding_mode
-        self.pruning_first = config["training_parameters"]["pruning_first"]
-        self.enable_quantization = config["quantization_parameters"]["enable_quantization"]
-        self.use_high_granularity_quantization = config["quantization_parameters"]["use_high_granularity_quantization"]
-        self.enable_pruning = config["pruning_parameters"]["enable_pruning"]
-
-    def save_weights(self):
-        self.init_weight = self.weight.clone()
-
-    def rewind_weights(self):
-        self.weight.data = self.init_weight.clone()
-
-    def hgq_loss(self):
-        if self.pruning_layer.is_pretraining:
-            return 0.0
-        loss = (torch.sum(self.hgq_weight.quantizer.i) + torch.sum(self.hgq_weight.quantizer.f)) * self.hgq_gamma
-        if self.bias is not None:
-            loss += (torch.sum(self.hgq_bias.quantizer.i) + torch.sum(self.hgq_bias.quantizer.f)) * self.hgq_gamma
-        return loss
-
-    def quantize(self, weight, bias):
-        if self.enable_quantization:
-            if self.use_high_granularity_quantization:
-                weight = self.hgq_weight(weight)
-                bias = None if bias is None else self.hgq_bias(bias)
-            else:
-                weight = self.quantizer(weight, k=torch.tensor(1.0), i=self.i_weight, f=self.f_weight, training=True)
-                bias = (
-                    None
-                    if bias is None
-                    else self.quantizer(bias, k=torch.tensor(1.0), i=self.i_bias, f=self.f_bias, training=True)
-                )
-        return weight, bias
-
-    def prune(self, weight):
-        if self.enable_pruning:
-            weight = self.pruning_layer(weight)
-        return weight
-
-    def prune_and_quantize(self, weight, bias):
-        if self.pruning_first:
-            weight = self.prune(weight)
-            weight, bias = self.quantize(weight, bias)
-        else:
-            weight, bias = self.quantize(weight, bias)
-            weight = self.prune(weight)
-        return weight, bias
-
-    def forward(self, x):
-        weight, bias = self.prune_and_quantize(self.weight, self.bias)
-        if self.pruning_method == "wanda":
-            self.pruning_layer.collect_input(x)
-        x = F.conv2d(
-            input=x,
-            weight=weight,
-            bias=bias,
-            stride=self.stride,
-            padding=self.padding,
-            dilation=self.dilation,
-            groups=self.groups,
+def add_default_layer_quantization_pruning_to_config(model, config):
+    if keras.backend.backend() == "torch":
+        from pquant.core.torch_impl.compressed_layers_torch import (
+            add_default_layer_quantization_pruning_to_config_torch,
         )
-        if self.pruning_method == "continual_learning":
-            self.pruning_layer.collect_output(x)
-        return x
 
-
-class CompressedLayerConv1d(nn.Module):
-    def __init__(self, config, layer):
-        super().__init__()
-        self.f_weight = torch.tensor(config["quantization_parameters"]["default_fractional_bits"])
-        self.i_weight = torch.tensor(config["quantization_parameters"]["default_integer_bits"])
-        self.f_bias = torch.tensor(config["quantization_parameters"]["default_fractional_bits"])
-        self.i_bias = torch.tensor(config["quantization_parameters"]["default_integer_bits"])
-        self.pruning_layer = get_pruning_layer(config=config, layer=layer, out_size=layer.out_channels)
-        self.pruning_method = config["pruning_parameters"]["pruning_method"]
-        overflow = "SAT_SYM" if config["quantization_parameters"]["use_symmetric_quantization"] else "SAT"
-        self.quantizer = get_fixed_quantizer(overflow_mode=overflow)
-        self.weight = nn.Parameter(layer.weight.clone())
-        self.init_weight = self.weight.clone()
-        if config["quantization_parameters"]["use_high_granularity_quantization"]:
-            self.hgq_weight = Quantizer(
-                k0=1.0,
-                i0=self.i_weight,
-                f0=self.f_weight,
-                round_mode="RND",
-                overflow_mode=overflow,
-                q_type="kif",
-                homogeneous_axis=(),
-            )
-            self.hgq_weight.build(self.weight.shape)
-            if layer.bias is not None:
-                self.hgq_bias = Quantizer(
-                    k0=1.0,
-                    i0=self.i_bias,
-                    f0=self.f_bias,
-                    round_mode="RND",
-                    overflow_mode=overflow,
-                    q_type="kif",
-                    homogeneous_axis=(),
-                )
-                self.hgq_bias.build(layer.bias.shape)
-            self.hgq_gamma = config["quantization_parameters"]["hgq_gamma"]
-
-        self.bias = nn.Parameter(layer.bias.clone()) if layer.bias is not None else None
-        self.stride = layer.stride
-        self.dilation = layer.dilation
-        self.padding = layer.padding
-        self.groups = layer.groups
-        self.in_channels = layer.in_channels
-        self.out_channels = layer.out_channels
-        self.kernel_size = layer.kernel_size
-        self.padding_mode = layer.padding_mode
-        self.pruning_first = config["training_parameters"]["pruning_first"]
-        self.enable_quantization = config["quantization_parameters"]["enable_quantization"]
-        self.use_high_granularity_quantization = config["quantization_parameters"]["use_high_granularity_quantization"]
-        self.enable_pruning = config["pruning_parameters"]["enable_pruning"]
-
-    def save_weights(self):
-        self.init_weight = self.weight.clone()
-
-    def rewind_weights(self):
-        self.weight.data = self.init_weight.clone()
-
-    def hgq_loss(self):
-        if self.pruning_layer.is_pretraining:
-            return 0.0
-        loss = (torch.sum(self.hgq_weight.quantizer.i) + torch.sum(self.hgq_weight.quantizer.f)) * self.hgq_gamma
-        if self.bias is not None:
-            loss += (torch.sum(self.hgq_bias.quantizer.i) + torch.sum(self.hgq_bias.quantizer.f)) * self.hgq_gamma
-        return loss
-
-    def quantize(self, weight, bias):
-        if self.enable_quantization:
-            if self.use_high_granularity_quantization:
-                weight = self.hgq_weight(weight)
-                bias = None if bias is None else self.hgq_bias(bias)
-            else:
-                weight = self.quantizer(weight, k=torch.tensor(1.0), i=self.i_weight, f=self.f_weight, training=True)
-                bias = (
-                    None
-                    if bias is None
-                    else self.quantizer(bias, k=torch.tensor(1.0), i=self.i_bias, f=self.f_bias, training=True)
-                )
-        return weight, bias
-
-    def prune(self, weight):
-        if self.enable_pruning:
-            weight = self.pruning_layer(weight)
-        return weight
-
-    def prune_and_quantize(self, weight, bias):
-        if self.pruning_first:
-            weight = self.prune(weight)
-            weight, bias = self.quantize(weight, bias)
-        else:
-            weight, bias = self.quantize(weight, bias)
-            weight = self.prune(weight)
-        return weight, bias
-
-    def forward(self, x):
-        weight, bias = self.prune_and_quantize(self.weight, self.bias)
-        if self.pruning_method == "wanda":
-            self.pruning_layer.collect_input(x)
-        x = F.conv1d(
-            input=x,
-            weight=weight,
-            bias=bias,
-            stride=self.stride,
-            padding=self.padding,
-            dilation=self.dilation,
-            groups=self.groups,
-        )
-        if self.pruning_method == "continual_learning":
-            self.pruning_layer.collect_output(x)
-        return x
-
-
-def add_pruning_and_quantization(model, config, input_shape):
-    model = add_quantized_activations_to_model_layer(model, config)
-    # model = add_quantized_activations_to_model_functional(model, config)
-    model = add_pruning_to_model(model, config)
-    model = disable_pruning_from_layers(model, config)
-    model = add_layer_specific_quantization_to_model(model, config)
-    model(torch.rand(input_shape, device=next(model.parameters()).device))
-    return model
-
-
-def add_layer_specific_quantization_to_model(module, config):
-    for name, layer in module.named_modules():
-        if layer.__class__ in [CompressedLayerLinear, CompressedLayerConv2d, CompressedLayerConv1d]:
-            if name in config["quantization_parameters"]["layer_specific"]:
-                if "weight" in config["quantization_parameters"]["layer_specific"][name]:
-                    weight_int_bits = config["quantization_parameters"]["layer_specific"][name]["weight"]["integer_bits"]
-                    weight_fractional_bits = config["quantization_parameters"]["layer_specific"][name]["weight"][
-                        "fractional_bits"
-                    ]
-                    layer.i_weight = torch.tensor(weight_int_bits)
-                    layer.f_weight = torch.tensor(weight_fractional_bits)
-                if "bias" in config["quantization_parameters"]["layer_specific"][name]:
-                    bias_int_bits = config["quantization_parameters"]["layer_specific"][name]["bias"]["integer_bits"]
-                    bias_fractional_bits = config["quantization_parameters"]["layer_specific"][name]["bias"][
-                        "fractional_bits"
-                    ]
-                    layer.i_bias = torch.tensor(bias_int_bits)
-                    layer.f_bias = torch.tensor(bias_fractional_bits)
-    return module
-
-
-def add_quantized_activations_to_model_layer(module, config):
-    if not config["quantization_parameters"]["enable_quantization"]:
-        return module
-    # Replaces ReLU and Tanh layers with quantized versions
-    for name, layer in module.named_children():
-        i = config["quantization_parameters"]["default_integer_bits"]
-        f = config["quantization_parameters"]["default_fractional_bits"]
-        if layer.__class__ in [nn.ReLU]:
-            if name in config["quantization_parameters"]["layer_specific"]:
-                i = config["quantization_parameters"]["layer_specific"][name]["integer_bits"]
-                f = config["quantization_parameters"]["layer_specific"][name]["fractional_bits"]
-            else:
-                # For ReLU, if using default values, add 1 bit since values are unsigned.
-                # Otherwise user provides bits. TODO: Find better way to do this
-                f = config["quantization_parameters"]["default_fractional_bits"] + 1
-            relu = QuantizedReLU(config, i=i, f=f)
-            setattr(module, name, relu)
-        elif layer.__class__ in [nn.Tanh]:
-            if name in config["quantization_parameters"]["layer_specific"]:
-                f = config["quantization_parameters"]["layer_specific"][name]["fractional_bits"]
-            tanh = QuantizedTanh(config, i=i, f=f)
-            setattr(module, name, tanh)
-        else:
-            layer = add_quantized_activations_to_model_layer(layer, config)
-    return module
-
-
-def add_quantized_activations_to_model_functional(module, config):
-    # Currently not in use. TODO: Fix this
-    if config["quantization_parameters"]["use_high_granularity_quantization"]:
-        return module
-    # Replaces functional activation calls with quantized versions
-    traced_model = symbolic_trace(module)
-    for node in traced_model.graph.nodes:
-        if node.op in ["call_method", "call_function"] and (node.target == "tanh" or "function relu" in str(node.target)):
-            with traced_model.graph.inserting_after(node):
-                if node.name in config["quantization_parameters"]["layer_specific"]:
-                    bits = config["quantization_parameters"]["layer_specific"][node.name]["bits"]
-                else:
-                    bits = (
-                        config["quantization_parameters"]["default_integer_bits"]
-                        + config["quantization_parameters"]["default_fractional_bits"]
-                        + 1
-                    )  # 1 sign bit
-                kwargs = {"bits": bits}
-                if node.target == "tanh":
-                    kwargs["use_real_tanh"] = config["quantization_parameters"]["use_real_tanh"]
-                    kwargs["use_symmetric"] = config["quantization_parameters"]["use_symmetric_quantization"]
-                    # new_node = traced_model.graph.call_function(quantized_tanh, node.args, kwargs)
-                else:
-                    kwargs = {"integer_bits": config["quantization_parameters"]["default_integer_bits"], "bits": bits}
-                    # new_node = traced_model.graph.call_function(quantized_relu, node.args, kwargs)
-                # node.replace_all_uses_with(new_node)
-            traced_model.graph.erase_node(node)
-
-    traced_model.graph.lint()
-    traced_model.recompile()
-    return traced_model
-
-
-def disable_pruning_from_layers(module, config):
-    for name, layer in module.named_modules():
-        enable_pruning = name not in config["pruning_parameters"]["disable_pruning_for_layers"]
-        if layer.__class__ in [CompressedLayerLinear, CompressedLayerConv2d, CompressedLayerConv1d] and not enable_pruning:
-            layer.enable_pruning = enable_pruning
-    return module
-
-
-def add_pruning_to_model(module, config):
-    for name, layer in module.named_children():
-        if layer.__class__ is nn.Linear:
-            sparse_layer = CompressedLayerLinear(config, layer)
-            sparse_layer.pruning_layer.build(layer.weight.shape)
-            setattr(module, name, sparse_layer)
-        elif layer.__class__ is nn.Conv2d:
-            sparse_layer = CompressedLayerConv2d(config, layer)
-            sparse_layer.pruning_layer.build(layer.weight.shape)
-            setattr(module, name, sparse_layer)
-        elif layer.__class__ is nn.Conv1d:
-            sparse_layer = CompressedLayerConv1d(config, layer)
-            sparse_layer.pruning_layer.build(layer.weight.shape)
-            setattr(module, name, sparse_layer)
-        else:
-            add_pruning_to_model(layer, config)
-    return module
-
-
-def remove_pruning_from_model(module, config):
-    for name, layer in module.named_children():
-        if isinstance(layer, CompressedLayerLinear):
-            if config["pruning_parameters"]["pruning_method"] == "pdp":  # Find better solution later
-                if config["training_parameters"]["pruning_first"]:
-                    weight = layer.pruning_layer.get_hard_mask(layer.weight) * layer.weight
-                    weight, bias = layer.quantize(weight, layer.bias)
-                else:
-                    weight, bias = layer.quantize(layer.weight, layer.bias)
-                    weight = layer.pruning_layer.get_hard_mask(weight) * weight
-            else:
-                weight, bias = layer.prune_and_quantize(layer.weight, layer.bias)
-            out_features = layer.out_features
-            bias_values = bias
-            in_features = layer.in_features
-            bias = True if bias_values is not None else False
-            setattr(module, name, nn.Linear(in_features=in_features, out_features=out_features, bias=bias))
-            getattr(module, name).weight.data.copy_(weight)
-            if getattr(module, name).bias is not None:
-                getattr(module, name).bias.data.copy_(bias_values.data)
-        elif isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d)):
-            if config["pruning_parameters"]["pruning_method"] == "pdp":  # Find better solution later
-                if config["training_parameters"]["pruning_first"]:
-                    weight = layer.pruning_layer.get_hard_mask(layer.weight) * layer.weight
-                    weight, bias = layer.quantize(weight, layer.bias)
-                else:
-                    weight, bias = layer.quantize(layer.weight, layer.bias)
-                    weight = layer.pruning_layer.get_hard_mask(weight) * weight
-            else:
-                weight, bias = layer.prune_and_quantize(layer.weight, layer.bias)
-            bias_values = bias
-            bias = True if bias_values is not None else False
-            conv = nn.Conv2d if isinstance(layer, CompressedLayerConv2d) else nn.Conv1d
-            setattr(
-                module,
-                name,
-                conv(
-                    layer.in_channels,
-                    layer.out_channels,
-                    layer.kernel_size,
-                    layer.stride,
-                    layer.padding,
-                    layer.dilation,
-                    layer.groups,
-                    bias,
-                    layer.padding_mode,
-                ),
-            )
-            getattr(module, name).weight.data.copy_(weight)
-            if getattr(module, name).bias is not None:
-                getattr(module, name).bias.data.copy_(bias_values.data)
-        else:
-            remove_pruning_from_model(layer, config)
-    return module
-
-
-def call_post_round_functions(model, rewind, rounds, r):
-    if rewind == "round":
-        rewind_weights_functions(model)
-    elif rewind == "post-ticket-search" and r == rounds - 1:
-        rewind_weights_functions(model)
+        return add_default_layer_quantization_pruning_to_config_torch(config, model)
     else:
-        post_round_functions(model)
+        from pquant.core.tf_impl.compressed_layers_tf import (
+            add_default_layer_quantization_pruning_to_config_tf,
+        )
+
+        return add_default_layer_quantization_pruning_to_config_tf(config, model)
 
 
-def post_epoch_functions(model, epoch, total_epochs, **kwargs):
-    for layer in model.modules():
-        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
-            layer.pruning_layer.post_epoch_function(epoch, total_epochs, **kwargs)
+def add_compression_layers(model, config, input_shape):
+    if keras.backend.backend() == "torch":
+        from pquant.core.torch_impl.compressed_layers_torch import (
+            add_compression_layers_torch,
+        )
+
+        return add_compression_layers_torch(model, config, input_shape)
+    else:
+        from pquant.core.tf_impl.compressed_layers_tf import add_compression_layers_tf
+
+        return add_compression_layers_tf(model, config, input_shape)
 
 
-def pre_epoch_functions(model, epoch, total_epochs):
-    for layer in model.modules():
-        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
-            layer.pruning_layer.pre_epoch_function(epoch, total_epochs)
-
-
-def post_round_functions(model):
-    for layer in model.modules():
-        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
-            layer.pruning_layer.post_round_function()
-
-
-def save_weights_functions(model):
-    for layer in model.modules():
-        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
-            layer.save_weights()
-
-
-def rewind_weights_functions(model):
-    for layer in model.modules():
-        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
-            layer.rewind_weights()
-
-
-def pre_finetune_functions(model):
-    for layer in model.modules():
-        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
-            layer.pruning_layer.pre_finetune_function()
-
-
-def post_pretrain_functions(model, config):
-    for layer in model.modules():
-        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
-            layer.pruning_layer.post_pre_train_function()
-        elif isinstance(layer, (QuantizedReLU, QuantizedTanh)):
-            layer.post_pre_train_function()
-    if config["pruning_parameters"]["pruning_method"] == "pdp" or config["pruning_parameters"]["pruning_method"] == "wanda":
-        pdp_setup(model, config)
-
-
-def pdp_setup(model, config):
-    """
-    Calculates a global sparsity threshold. Initializes target sparsity for each layer, which depends on
-    how large percentage of weights in the layer is smaller than the global threshold
-    """
-    global_weights = None
-    for layer in model.modules():
-        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
-            if global_weights is None:
-                global_weights = layer.weight.flatten()
-            else:
-                global_weights = torch.concat((global_weights, layer.weight.flatten()))
-
-    abs_global_weights = torch.abs(global_weights)
-    global_weight_topk, _ = torch.topk(abs_global_weights, abs_global_weights.numel())
-    threshold = global_weight_topk[int((1 - config["pruning_parameters"]["sparsity"]) * global_weight_topk.numel())]
-    global_weights_below_threshold = torch.where(abs_global_weights < threshold, 1, 0)
-    idx = 0
-    for layer in model.modules():
-        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
-            weight_size = layer.weight.numel()
-            w = torch.sum(global_weights_below_threshold[idx : idx + weight_size])
-            layer.pruning_layer.init_r = w / weight_size
-            layer.pruning_layer.sparsity = w / weight_size  # Wanda
-            idx += weight_size
-
-
-@torch.no_grad
 def get_layer_keep_ratio(model):
-    total_w = 0
-    remaining_weights = 0
-    for layer in model.modules():
-        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
-            if layer.pruning_first:
-                weight = layer.pruning_layer.mask * layer.weight
-                weight, bias = layer.quantize(weight, layer.bias)
-                total_w += layer.weight.numel()
-                rem = torch.count_nonzero(weight)
-                remaining_weights += rem
-            else:
-                weight, bias = layer.quantize(layer.weight, layer.bias)
-                weight = layer.pruning_layer.mask * weight
-                total_w += weight.numel()
-                rem = torch.count_nonzero(weight)
-                remaining_weights += rem
-        elif isinstance(layer, (nn.Conv2d, nn.Conv1d, nn.Linear)):
-            total_w += layer.weight.numel()
-            remaining_weights += torch.count_nonzero(layer.weight)
-    if total_w != 0:
-        return remaining_weights / total_w
-    return 0.0
+    if keras.backend.backend() == "torch":
+        from pquant.core.torch_impl.compressed_layers_torch import (
+            get_layer_keep_ratio_torch,
+        )
+
+        return get_layer_keep_ratio_torch(model)
+    else:
+        from pquant.core.tf_impl.compressed_layers_tf import get_layer_keep_ratio_tf
+
+        return get_layer_keep_ratio_tf(model)
 
 
 def get_model_losses(model, losses):
-    for layer in model.modules():
-        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
-            loss = layer.pruning_layer.calculate_additional_loss()
-            if layer.use_high_granularity_quantization:
-                loss += layer.hgq_loss()
-            losses += loss
-        elif isinstance(layer, (QuantizedReLU, QuantizedTanh)):
-            if layer.use_high_granularity_quantization:
-                losses += layer.hgq_loss()
-    return losses
+    if keras.backend.backend() == "torch":
+        from pquant.core.torch_impl.compressed_layers_torch import (
+            get_model_losses_torch,
+        )
+
+        return get_model_losses_torch(model, losses)
+    else:
+        from pquant.core.tf_impl.compressed_layers_tf import get_model_losses_tf
+
+        return get_model_losses_tf(model, losses)
 
 
-def create_default_layer_quantization_pruning_config(model):
-    config = {"layer_specific": {}, "disable_pruning_for_layers": []}
-    for name, layer in model.named_modules():
-        if layer.__class__ in [nn.Linear, nn.Conv1d, nn.Conv2d]:
-            if layer.bias is None:
-                config["layer_specific"][name] = {"weight": {"integer_bits": 0, "fractional_bits": 7}}
-            else:
-                config["layer_specific"][name] = {
-                    "weight": {"integer_bits": 0, "fractional_bits": 7},
-                    "bias": {"integer_bits": 0, "fractional_bits": 7},
-                }
-            config["disable_pruning_for_layers"].append(name)
-        elif layer.__class__ in [nn.Tanh, nn.ReLU]:
-            config["layer_specific"][name] = {"integer_bits": 0, "fractional_bits": 7}
-    traced_model = symbolic_trace(model)
-    for node in traced_model.graph.nodes:
-        if node.op == "call_method" and node.target == "tanh":
-            config["layer_specific"][node.name] = {"bits": 8}
-        elif node.op == "call_function" and "function relu" == str(node.target):
-            config["layer_specific"][node.name] = {"bits": 8}
-    return config
+def remove_pruning_from_model(model, config):
+    if keras.backend.backend() == "torch":
+        from pquant.core.torch_impl.compressed_layers_torch import (
+            remove_pruning_from_model_torch,
+        )
 
+        return remove_pruning_from_model_torch(model, config)
+    else:
+        from pquant.core.tf_impl.compressed_layers_tf import (
+            remove_pruning_from_model_tf,
+        )
 
-def add_default_layer_quantization_pruning_to_config(config, model):
-    custom_scheme = create_default_layer_quantization_pruning_config(model)
-    config["quantization_parameters"]["layer_specific"] = custom_scheme["layer_specific"]
-    config["pruning_parameters"]["disable_pruning_for_layers"] = custom_scheme["disable_pruning_for_layers"]
-    return config
+        return remove_pruning_from_model_tf(model, config)

--- a/src/pquant/core/tf_impl/compressed_layers_tf.py
+++ b/src/pquant/core/tf_impl/compressed_layers_tf.py
@@ -1,0 +1,478 @@
+import keras
+from hgq.quantizer import Quantizer
+from keras import ops
+from quantizers import get_fixed_quantizer
+
+from pquant.core.activations_quantizer import QuantizedReLU, QuantizedTanh
+from pquant.core.utils import get_pruning_layer
+
+
+class CompressedLayerBase(keras.layers.Layer):
+    def __init__(self, config, layer, layer_type):
+        super().__init__()
+        i_bits = config["quantization_parameters"]["default_integer_bits"]
+        f_bits = config["quantization_parameters"]["default_fractional_bits"]
+        self.i_weight = ops.convert_to_tensor(i_bits)
+        self.f_weight = ops.convert_to_tensor(f_bits)
+        self.i_bias = ops.convert_to_tensor(i_bits)
+        self.f_bias = ops.convert_to_tensor(f_bits)
+        self.pruning_layer = get_pruning_layer(config=config, layer_type=layer_type)
+        self.pruning_method = config["pruning_parameters"]["pruning_method"]
+        self.overflow = "SAT_SYM" if config["quantization_parameters"]["use_symmetric_quantization"] else "SAT"
+        self.quantizer = get_fixed_quantizer(overflow_mode=self.overflow)
+        self.weight = self.add_weight(layer.kernel.shape, trainable=True)
+        self.init_weight = self.weight.value
+        self.hgq_gamma = config["quantization_parameters"]["hgq_gamma"]
+
+        self.bias = self.add_weight(layer.bias.shape, trainable=True) if layer.bias is not None else None
+        self.pruning_first = config["training_parameters"]["pruning_first"]
+        self.enable_quantization = config["quantization_parameters"]["enable_quantization"]
+        self.use_high_granularity_quantization = config["quantization_parameters"]["use_high_granularity_quantization"]
+        self.enable_pruning = config["pruning_parameters"]
+        self.channel_format = keras.backend.image_data_format()
+        self.transpose = None
+
+        if hasattr(layer, "use_bias"):
+            self.use_bias = layer.use_bias
+        else:
+            self.use_bias = self.bias is not None
+
+    def set_quantization_bits(self, i_bits_w, f_bits_w, i_bits_b, f_bits_b):
+        self.i_weight = ops.convert_to_tensor(i_bits_w)
+        self.f_weight = ops.convert_to_tensor(f_bits_w)
+        self.i_bias = ops.convert_to_tensor(i_bits_b)
+        self.f_bias = ops.convert_to_tensor(f_bits_b)
+
+    def set_enable_pruning(self, enable_pruning):
+        self.enable_pruning = enable_pruning
+
+    def build(self, input_shape):
+        super().build(input_shape)
+        if self.use_high_granularity_quantization:
+            self.hgq_weight = Quantizer(
+                k0=1.0,
+                i0=self.i_weight,
+                f0=self.f_weight,
+                round_mode="RND",
+                overflow_mode=self.overflow,
+                q_type="kif",
+            )
+            self.hgq_weight.build(self.weight.shape)
+            if self.use_bias:
+                self.hgq_bias = Quantizer(
+                    k0=1.0,
+                    i0=self.i_bias,
+                    f0=self.RND,
+                    round_mode="TRN",
+                    overflow_mode=self.overflow,
+                    q_type="kif",
+                )
+                self.hgq_bias.build(self.bias.shape)
+
+    def save_weights(self):
+        self.init_weight = self.weight.value
+
+    def rewind_weights(self):
+        self.weight.assign(self.init_weight)
+
+    def hgq_loss(self):
+        if self.pruning_layer.is_pretraining:
+            return 0.0
+        loss = (ops.sum(self.hgq_weight.quantizer.i) + ops.sum(self.hgq_weight.quantizer.f)) * self.hgq_gamma
+        if self.bias is not None:
+            loss += (ops.sum(self.hgq_bias.quantizer.i) + ops.sum(self.hgq_bias.quantizer.f)) * self.hgq_gamma
+        return loss
+
+    def quantize_i(self, weight, bias):
+        if self.enable_quantization:
+            if self.use_high_granularity_quantization:
+                weight = self.hgq_weight(weight)
+                bias = None if bias is None else self.hgq_bias(bias)
+            else:
+                weight = self.quantizer(
+                    weight, k=ops.convert_to_tensor(1.0), i=self.i_weight, f=self.f_weight, training=True
+                )
+                bias = (
+                    None
+                    if bias is None
+                    else self.quantizer(bias, k=ops.convert_to_tensor(1.0), i=self.i_bias, f=self.f_bias, training=True)
+                )
+        return weight, bias
+
+    def prune(self, weight):
+        if self.enable_pruning:
+            if self.channel_format == "channels_last":
+                weight = ops.transpose(weight, self.transpose)
+            weight = self.pruning_layer(weight)
+            if self.channel_format == "channels_last":  # Transpose back
+                weight = ops.transpose(weight, self.transpose)
+        return weight
+
+    def prune_and_quantize(self, weight, bias):
+        weight = ops.cast(weight, weight.dtype)
+        bias = ops.cast(bias, bias.dtype) if bias is not None else None
+        if self.pruning_first:
+            weight = self.prune(weight)
+            weight, bias = self.quantize_i(weight, bias)
+        else:
+            weight, bias = self.quantize_i(weight, bias)
+            weight = self.prune(weight)
+        return weight, bias
+
+    def call(self, x):
+        return x
+
+
+class CompressedLayerDepthwiseConv2dKeras(CompressedLayerBase):
+    def __init__(self, config, layer, layer_type):
+        super().__init__(config, layer, layer_type)
+        self.depthwise_regularizer = layer.depthwise_regularizer
+        self.use_bias = layer.use_bias
+        self.strides = layer.strides
+        self.dilation_rate = layer.dilation_rate
+        self.padding = layer.padding
+        self.kernel_size = layer.kernel_size
+        self.transpose = (2, 3, 0, 1)
+
+    def call(self, x, training=None):
+        weight, bias = self.prune_and_quantize(self.weight, self.bias)
+        if self.pruning_method == "wanda":
+            self.pruning_layer.collect_input(x, weight, training)
+        x = ops.depthwise_conv(
+            x, weight, strides=self.strides, padding=self.padding, data_format=None, dilation_rate=self.dilation_rate
+        )
+        if self.pruning_method == "activation_pruning":
+            self.pruning_layer.collect_output(x, training)
+        return x
+
+
+class CompressedLayerConv2dKeras(CompressedLayerBase):
+    def __init__(self, config, layer, layer_type):
+        super().__init__(config, layer, layer_type)
+        self.kernel_regularizer = layer.kernel_regularizer
+        self.filters = layer.filters
+        self.use_bias = layer.use_bias
+        self.strides = layer.strides
+        self.dilation_rate = layer.dilation_rate
+        self.padding = layer.padding
+        self.kernel_size = layer.kernel_size
+        self.groups = layer.groups
+        self.transpose = (2, 3, 0, 1)
+
+    def build(self, input_shape):
+        super().build(input_shape)
+
+    def call(self, x, training=None):
+        weight, bias = self.prune_and_quantize(self.weight, self.bias)
+        if self.pruning_method == "wanda":
+            self.pruning_layer.collect_input(x, weight, training)
+        x = ops.conv(
+            x, weight, strides=self.strides, padding=self.padding, data_format=None, dilation_rate=self.dilation_rate
+        )
+        if self.bias is not None:
+            x = ops.add(x, bias)
+        if self.pruning_method == "activation_pruning":
+            self.pruning_layer.collect_output(x, training)
+        return x
+
+
+class CompressedLayerDenseKeras(CompressedLayerBase):
+    def __init__(self, config, layer, layer_type):
+        super().__init__(config, layer, layer_type)
+        self.kernel_regularizer = layer.kernel_regularizer
+        self.use_bias = layer.use_bias
+        self.units = layer.units
+        self.transpose = (1, 0)
+
+    def call(self, x, training=None):
+        weight, bias = self.prune_and_quantize(self.weight, self.bias)
+        if self.pruning_method == "wanda":
+            self.pruning_layer.collect_input(x, weight, training)
+        x = ops.matmul(x, weight)
+        if self.bias is not None:
+            x = ops.add(x, bias)
+        if self.pruning_method == "activation_pruning":
+            self.pruning_layer.collect_output(x, training)
+        return x
+
+
+def call_post_round_functions(model, rewind, rounds, r):
+    if rewind == "round":
+        rewind_weights_functions(model)
+    elif rewind == "post-ticket-search" and r == rounds - 1:
+        rewind_weights_functions(model)
+    else:
+        post_round_functions(model)
+
+
+def _prune_and_quantize_layer(layer, use_bias):
+    layer_weights = layer.get_weights()
+    layer_weight = ops.cast(layer_weights[0], layer_weights[0].dtype)
+    layer_bias = ops.cast(layer_weights[1], layer_weights[1].dtype) if use_bias else None
+    weight, bias = layer.prune_and_quantize(layer_weight, layer_bias)
+    return weight, bias
+
+
+def remove_pruning_from_model_tf(model, config):
+    x = model.layers[0].output
+    for layer in model.layers[1:]:
+        if isinstance(layer, CompressedLayerDepthwiseConv2dKeras):
+            new_layer = keras.layers.DepthwiseConv2D(
+                kernel_size=layer.kernel_size,
+                strides=layer.strides,
+                padding=layer.padding,
+                dilation_rate=layer.dilation_rate,
+                use_bias=layer.use_bias,
+                depthwise_regularizer=layer.depthwise_regularizer,
+                activity_regularizer=layer.activity_regularizer,
+            )
+            x = new_layer(x)
+            use_bias = layer.use_bias
+            weight, bias = _prune_and_quantize_layer(layer, use_bias)
+            new_layer.set_weights([weight, bias] if use_bias else [weight])
+        elif isinstance(layer, CompressedLayerConv2dKeras):
+            new_layer = keras.layers.Conv2D(
+                filters=layer.filters,
+                kernel_size=layer.kernel_size,
+                strides=layer.strides,
+                padding=layer.padding,
+                dilation_rate=layer.dilation_rate,
+                use_bias=layer.use_bias,
+                kernel_regularizer=layer.kernel_regularizer,
+                activity_regularizer=layer.activity_regularizer,
+            )
+            x = new_layer(x)
+            use_bias = layer.use_bias
+            weight, bias = _prune_and_quantize_layer(layer, use_bias)
+            new_layer.set_weights([weight, bias] if use_bias else [weight])
+        elif isinstance(layer, CompressedLayerDenseKeras):
+            new_layer = keras.layers.Dense(
+                units=layer.units, use_bias=layer.use_bias, kernel_regularizer=layer.kernel_regularizer
+            )
+            x = new_layer(x)
+            use_bias = new_layer.use_bias
+            weight, bias = _prune_and_quantize_layer(layer, use_bias)
+            new_layer.set_weights([weight, bias] if use_bias else [weight])
+        else:
+            x = layer(x)
+    replaced_model = keras.Model(inputs=model.inputs, outputs=x)
+    return replaced_model
+
+
+def post_epoch_functions(model, epoch, total_epochs, **kwargs):
+    for layer in model.layers:
+        if isinstance(layer, (CompressedLayerDepthwiseConv2dKeras, CompressedLayerConv2dKeras, CompressedLayerDenseKeras)):
+            layer.pruning_layer.post_epoch_function(epoch, total_epochs, **kwargs)
+
+
+def pre_epoch_functions(model, epoch, total_epochs):
+    for layer in model.layers:
+        if isinstance(layer, (CompressedLayerDepthwiseConv2dKeras, CompressedLayerConv2dKeras, CompressedLayerDenseKeras)):
+            layer.pruning_layer.pre_epoch_function(epoch, total_epochs)
+
+
+def post_round_functions(model):
+    for layer in model.layers:
+        if isinstance(layer, (CompressedLayerDepthwiseConv2dKeras, CompressedLayerConv2dKeras, CompressedLayerDenseKeras)):
+            layer.pruning_layer.post_round_function()
+
+
+def save_weights_functions(model):
+    for layer in model.layers:
+        if isinstance(layer, (CompressedLayerDepthwiseConv2dKeras, CompressedLayerConv2dKeras, CompressedLayerDenseKeras)):
+            layer.save_weights()
+
+
+def rewind_weights_functions(model):
+    for layer in model.layers:
+        if isinstance(layer, (CompressedLayerDepthwiseConv2dKeras, CompressedLayerConv2dKeras, CompressedLayerDenseKeras)):
+            layer.rewind_weights()
+
+
+def pre_finetune_functions(model):
+    for layer in model.layers:
+        if isinstance(layer, (CompressedLayerDepthwiseConv2dKeras, CompressedLayerConv2dKeras, CompressedLayerDenseKeras)):
+            layer.pruning_layer.pre_finetune_function()
+
+
+def post_pretrain_functions(model, config):
+    for layer in model.layers:
+        if isinstance(layer, (CompressedLayerDepthwiseConv2dKeras, CompressedLayerConv2dKeras, CompressedLayerDenseKeras)):
+            layer.pruning_layer.post_pre_train_function()
+    if config["pruning_parameters"]["pruning_method"] == "pdp" or config["pruning_parameters"]["pruning_method"] == "wanda":
+        pdp_setup(model, config)
+
+
+def pdp_setup(model, config):
+    """
+    Calculates a global sparsity threshold. Initializes target sparsity for each layer, which depends on
+    how large percentage of weights in the layer is smaller than the global threshold
+    """
+    global_weights = None
+    for layer in model.layers:
+        if isinstance(layer, (CompressedLayerDepthwiseConv2dKeras, CompressedLayerConv2dKeras, CompressedLayerDenseKeras)):
+            if global_weights is None:
+                global_weights = ops.reshape(layer.weight, -1)
+            else:
+                global_weights = ops.concatenate((global_weights, ops.reshape(layer.weight, -1)))
+
+    abs_global_weights = ops.abs(global_weights)
+    global_weight_topk, _ = ops.top_k(abs_global_weights, ops.size(abs_global_weights))
+    threshold = global_weight_topk[int((1 - config["pruning_parameters"]["sparsity"]) * float(ops.size(global_weight_topk)))]
+    global_weights_below_threshold = ops.where(abs_global_weights < threshold, 1, 0)
+    idx = 0
+    for layer in model.layers:
+        if isinstance(layer, (CompressedLayerDepthwiseConv2dKeras, CompressedLayerConv2dKeras, CompressedLayerDenseKeras)):
+            weight_size = ops.size(layer.weight)
+            w = ops.sum(global_weights_below_threshold[idx : idx + weight_size])
+            layer.pruning_layer.init_r = ops.convert_to_tensor(w / weight_size, dtype=layer.weight.dtype)
+            layer.pruning_layer.sparsity = ops.convert_to_tensor(w / weight_size, dtype=layer.weight.dtype)  # Wanda
+            idx += weight_size
+
+
+def get_layer_keep_ratio_tf(model):
+    total_w = 0
+    remaining_weights = 0
+    for layer in model.layers:
+        if isinstance(layer, (CompressedLayerDepthwiseConv2dKeras, CompressedLayerConv2dKeras, CompressedLayerDenseKeras)):
+            # weight, bias = layer.prune_and_quantize(layer.weight, layer.bias)
+            weight = ops.cast(layer.weight, layer.weight.dtype)
+            bias = ops.cast(layer.bias, layer.bias.dtype) if layer.bias is not None else None
+            weight, bias = layer.quantize_i(weight, bias)
+            transpose = layer.transpose
+            weight = layer.pruning_layer.get_hard_mask(ops.transpose(weight, transpose)) * ops.transpose(weight, transpose)
+            total_w += ops.size(layer.weight)
+            rem = ops.count_nonzero(weight)
+            remaining_weights += rem
+        elif isinstance(layer, (keras.layers.Conv2D, keras.layers.DepthwiseConv2D, keras.layers.Dense)):
+            weight = layer.get_weights()[0]
+            total_w += ops.size(weight)
+            remaining_weights += ops.count_nonzero(weight)
+    if total_w != 0:
+        return remaining_weights / total_w
+    return 0.0
+
+
+def get_model_losses_tf(model, losses):
+    for layer in model.layers:
+        if isinstance(layer, (CompressedLayerDepthwiseConv2dKeras, CompressedLayerConv2dKeras, CompressedLayerDenseKeras)):
+            loss = layer.pruning_layer.calculate_additional_loss()
+            if layer.use_high_granularity_quantization:
+                loss += layer.hgq_loss()
+            losses += loss
+    return losses
+
+
+def check_activation(layer, config):
+    quantization_enabled = config["quantization_parameters"]["enable_quantization"]
+    # Replaces activations that are part of a layer, by adding them as a layer
+    act = None
+    if hasattr(layer.activation, "__name__"):
+        if layer.activation.__name__ == "relu":
+            i_bits, f_bits = get_quantization_bits_activations(config, layer)
+            act = QuantizedReLU(config, i_bits, f_bits) if quantization_enabled else keras.layers.ReLU()
+        elif layer.activation.__name__ == "tanh":
+            i_bits, f_bits = get_quantization_bits_activations(config, layer)
+            act = (
+                QuantizedTanh(config, i=i_bits, f=f_bits)
+                if quantization_enabled
+                else keras.layers.Activation(activation="tanh")
+            )
+        else:
+            act = None
+    return act
+
+
+def add_compression_layers_tf(model, config, input_shape=None):
+    requires_transpose = (
+        keras.backend.image_data_format() == "channels_last"
+    )  # Pruning algorithms assume channels_first format
+    # Creates a new functional model from model, replacing certain layers with compressed / quantized variants
+    x = model.layers[0].output
+    for layer in model.layers[1:]:
+        act = None
+        if isinstance(layer, (keras.layers.DepthwiseConv2D)):
+            new_layer = CompressedLayerDepthwiseConv2dKeras(config, layer, layer_type="conv")
+            i_bits_w, f_bits_w, i_bits_b, f_bits_b = get_quantization_bits_weights_biases(config, layer.name)
+            new_layer.set_quantization_bits(i_bits_w, f_bits_w, i_bits_b, f_bits_b)
+            enable_pruning = get_enable_pruning(layer, config)
+            new_layer.set_enable_pruning(enable_pruning)
+            pruning_layer_input = new_layer.weight
+            if requires_transpose:
+                transpose_shape = (2, 3, 0, 1)
+                pruning_layer_input = ops.transpose(pruning_layer_input, transpose_shape)
+            new_layer.pruning_layer.build(pruning_layer_input.shape)
+            x = new_layer(x)
+            act = check_activation(layer, config)
+        elif isinstance(layer, (keras.layers.Conv2D)):
+            new_layer = CompressedLayerConv2dKeras(config, layer, layer_type="conv")
+            i_bits_w, f_bits_w, i_bits_b, f_bits_b = get_quantization_bits_weights_biases(config, layer.name)
+            new_layer.set_quantization_bits(i_bits_w, f_bits_w, i_bits_b, f_bits_b)
+            enable_pruning = get_enable_pruning(layer, config)
+            new_layer.set_enable_pruning(enable_pruning)
+            pruning_layer_input = new_layer.weight
+            if requires_transpose:
+                transpose_shape = (2, 3, 0, 1)
+                pruning_layer_input = ops.transpose(pruning_layer_input, transpose_shape)
+            new_layer.pruning_layer.build(pruning_layer_input.shape)
+            x = new_layer(x)
+            act = check_activation(layer, config)
+        elif isinstance(layer, (keras.layers.Dense)):
+            new_layer = CompressedLayerDenseKeras(config, layer, layer_type="linear")
+            i_bits_w, f_bits_w, i_bits_b, f_bits_b = get_quantization_bits_weights_biases(config, layer.name)
+            new_layer.set_quantization_bits(i_bits_w, f_bits_w, i_bits_b, f_bits_b)
+            enable_pruning = get_enable_pruning(layer, config)
+            new_layer.set_enable_pruning(enable_pruning)
+            pruning_layer_input = new_layer.weight
+            if requires_transpose:
+                transpose_shape = (1, 0)
+                pruning_layer_input = ops.transpose(pruning_layer_input, transpose_shape)
+            new_layer.pruning_layer.build(pruning_layer_input.shape)
+            x = new_layer(x)
+            act = check_activation(layer, config)
+        # Activation layers
+        elif isinstance(layer, (keras.layers.ReLU)):
+            i_bits, f_bits = get_quantization_bits_activations(config, layer)
+            new_layer = QuantizedReLU(config, i_bits, f_bits)
+            x = new_layer(x)
+        elif isinstance(layer, keras.layers.Activation):
+            layer = check_activation(layer, config)
+            x = layer(x)
+        else:
+            x = layer(x)
+        if act is not None:
+            x = act(x)
+    replaced_model = keras.Model(inputs=model.inputs, outputs=x)
+    replaced_model(keras.random.normal(shape=input_shape))
+    return replaced_model
+
+
+def get_quantization_bits_activations(config, name):
+    i_bits = config["quantization_parameters"]["default_integer_bits"]
+    f_bits = config["quantization_parameters"]["default_fractional_bits"]
+    layer_specific = config["quantization_parameters"]["layer_specific"]
+    if name in layer_specific:
+        i_bits = layer_specific[name]["weight"]["integer_bits"]
+        f_bits = layer_specific[name]["weight"]["fractional_bits"]
+    return i_bits, f_bits
+
+
+def get_quantization_bits_weights_biases(config, name):
+    i_bits_w = i_bits_b = config["quantization_parameters"]["default_integer_bits"]
+    f_bits_w = f_bits_b = config["quantization_parameters"]["default_fractional_bits"]
+    layer_specific = config["quantization_parameters"]["layer_specific"]
+    if name in layer_specific:
+        if "weight" in layer_specific[name]:
+            i_bits_w = layer_specific[name]["weight"]["integer_bits"]
+            f_bits_w = layer_specific[name]["weight"]["fractional_bits"]
+        if "bias" in layer_specific[name]:
+            i_bits_b = layer_specific[name]["bias"]["integer_bits"]
+            f_bits_b = layer_specific[name]["bias"]["fractional_bits"]
+    return i_bits_w, f_bits_w, i_bits_b, f_bits_b
+
+
+def get_enable_pruning(layer, config):
+    enable_pruning = config["pruning_parameters"]["enable_pruning"]
+    if layer.name in config["pruning_parameters"]["disable_pruning_for_layers"]:
+        enable_pruning = False
+    return enable_pruning

--- a/src/pquant/core/tf_impl/compressed_layers_tf.py
+++ b/src/pquant/core/tf_impl/compressed_layers_tf.py
@@ -62,8 +62,8 @@ class CompressedLayerBase(keras.layers.Layer):
                 self.hgq_bias = Quantizer(
                     k0=1.0,
                     i0=self.i_bias,
-                    f0=self.RND,
-                    round_mode="TRN",
+                    f0=self.f_bias,
+                    round_mode="RND",
                     overflow_mode=self.overflow,
                     q_type="kif",
                 )
@@ -360,6 +360,9 @@ def get_model_losses_tf(model, losses):
             if layer.use_high_granularity_quantization:
                 loss += layer.hgq_loss()
             losses += loss
+        elif isinstance(layer, (QuantizedReLU, QuantizedTanh)):
+            if layer.use_high_granularity_quantization:
+                losses += layer.hgq_loss()
     return losses
 
 

--- a/src/pquant/core/tf_impl/train_tf.py
+++ b/src/pquant/core/tf_impl/train_tf.py
@@ -1,0 +1,49 @@
+import keras
+
+from pquant.core.tf_impl.compressed_layers_tf import (
+    call_post_round_functions,
+    post_epoch_functions,
+    post_pretrain_functions,
+    pre_epoch_functions,
+    pre_finetune_functions,
+    save_weights_functions,
+)
+
+
+def iterative_train_tf(model, config, train_func, valid_func, **kwargs):
+    """
+    Generic training loop, user provides training and validation functions
+    """
+    epoch = keras.ops.convert_to_tensor(0)  # Keeps track of all the epochs completed
+    training_config = config["training_parameters"]
+    if training_config["pretraining_epochs"] > 0:
+        for e in range(training_config["pretraining_epochs"]):
+            pre_epoch_functions(model, e, training_config["pretraining_epochs"])
+            v = train_func(model, epoch=epoch, **kwargs)
+            if not v:
+                return model, False
+            valid_func(model, epoch=epoch, **kwargs)
+            post_epoch_functions(model, e, training_config["pretraining_epochs"])
+            epoch += 1
+        post_pretrain_functions(model, config)
+    for r in range(training_config["rounds"]):
+        for e in range(training_config["epochs"]):
+            if r == 0 and training_config["save_weights_epoch"] == e:
+                save_weights_functions(model)
+            pre_epoch_functions(model, e, training_config["epochs"])
+            v = train_func(model, epoch=epoch, **kwargs)
+            if not v:
+                return model, False
+            valid_func(model, epoch=epoch, **kwargs)
+            post_epoch_functions(model, e, training_config["epochs"])
+            epoch += 1
+        call_post_round_functions(model, training_config["rewind"], training_config["rounds"], r)
+    pre_finetune_functions(model)
+    if training_config["fine_tuning_epochs"] > 0:
+        for e in range(training_config["fine_tuning_epochs"]):
+            pre_epoch_functions(model, e, training_config["fine_tuning_epochs"])
+            train_func(model, epoch=epoch, **kwargs)
+            valid_func(model, epoch=epoch, **kwargs)
+            post_epoch_functions(model, e, training_config["fine_tuning_epochs"])
+            epoch += 1
+    return model, True

--- a/src/pquant/core/tf_impl/train_tf.py
+++ b/src/pquant/core/tf_impl/train_tf.py
@@ -25,7 +25,7 @@ def iterative_train_tf(model, config, train_func, valid_func, **kwargs):
             valid_func(model, epoch=epoch, **kwargs)
             post_epoch_functions(model, e, training_config["pretraining_epochs"])
             epoch += 1
-        post_pretrain_functions(model, config)
+    post_pretrain_functions(model, config)
     for r in range(training_config["rounds"]):
         for e in range(training_config["epochs"]):
             if r == 0 and training_config["save_weights_epoch"] == e:

--- a/src/pquant/core/torch_impl/compressed_layers_torch.py
+++ b/src/pquant/core/torch_impl/compressed_layers_torch.py
@@ -647,7 +647,7 @@ def create_default_layer_quantization_pruning_config(model):
     return config
 
 
-def add_default_layer_quantization_pruning_to_config_torch(config, model):
+def add_default_layer_quantization_pruning_to_config_torch(model, config):
     custom_scheme = create_default_layer_quantization_pruning_config(model)
     config["quantization_parameters"]["layer_specific"] = custom_scheme["layer_specific"]
     config["pruning_parameters"]["disable_pruning_for_layers"] = custom_scheme["disable_pruning_for_layers"]

--- a/src/pquant/core/torch_impl/compressed_layers_torch.py
+++ b/src/pquant/core/torch_impl/compressed_layers_torch.py
@@ -1,0 +1,654 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from hgq.quantizer import Quantizer
+from quantizers import get_fixed_quantizer
+from torch.fx import symbolic_trace
+
+from pquant.core.activations_quantizer import QuantizedReLU, QuantizedTanh
+from pquant.core.utils import get_pruning_layer
+
+
+class CompressedLayerLinear(nn.Module):
+    def __init__(self, config, layer):
+        super().__init__()
+        self.f_weight = torch.tensor(config["quantization_parameters"]["default_fractional_bits"])
+        self.i_weight = torch.tensor(config["quantization_parameters"]["default_integer_bits"])
+        self.f_bias = torch.tensor(config["quantization_parameters"]["default_fractional_bits"])
+        self.i_bias = torch.tensor(config["quantization_parameters"]["default_integer_bits"])
+
+        self.in_features = layer.in_features
+        self.out_features = layer.out_features
+        self.weight = nn.Parameter(layer.weight.clone())
+        self.pruning_layer = get_pruning_layer(config=config, layer_type="linear")
+        self.pruning_method = config["pruning_parameters"]["pruning_method"]
+        overflow = "SAT_SYM" if config["quantization_parameters"]["use_symmetric_quantization"] else "SAT"
+        self.quantizer = get_fixed_quantizer(overflow_mode=overflow)
+        if config["quantization_parameters"]["use_high_granularity_quantization"]:
+            self.hgq_weight = Quantizer(
+                k0=1.0,
+                i0=self.i_weight,
+                f0=self.f_weight,
+                round_mode="RND",
+                overflow_mode=overflow,
+                q_type="kif",
+                homogeneous_axis=(),
+            )
+            self.hgq_weight.build(self.weight.shape)
+            if layer.bias is not None:
+                self.hgq_bias = Quantizer(
+                    k0=1.0,
+                    i0=self.i_bias,
+                    f0=self.f_bias,
+                    round_mode="RND",
+                    overflow_mode=overflow,
+                    q_type="kif",
+                    homogeneous_axis=(),
+                )
+                self.hgq_bias.build(layer.bias.shape)
+            self.hgq_gamma = config["quantization_parameters"]["hgq_gamma"]
+
+        self.bias = nn.Parameter(layer.bias.clone()) if layer.bias is not None else None
+        self.init_weight = self.weight.clone()
+        self.pruning_first = config["training_parameters"]["pruning_first"]
+        self.enable_quantization = config["quantization_parameters"]["enable_quantization"]
+        self.use_high_granularity_quantization = config["quantization_parameters"]["use_high_granularity_quantization"]
+        self.enable_pruning = config["pruning_parameters"]["enable_pruning"]
+
+    def save_weights(self):
+        self.init_weight = self.weight.clone()
+
+    def rewind_weights(self):
+        self.weight.data = self.init_weight.clone()
+
+    def hgq_loss(self):
+        if self.pruning_layer.is_pretraining:
+            return 0.0
+        loss = (torch.sum(self.hgq_weight.quantizer.i) + torch.sum(self.hgq_weight.quantizer.f)) * self.hgq_gamma
+        if self.bias is not None:
+            loss += (torch.sum(self.hgq_bias.quantizer.i) + torch.sum(self.hgq_bias.quantizer.f)) * self.hgq_gamma
+        return loss
+
+    def quantize(self, weight, bias):
+        if self.enable_quantization:
+            if self.use_high_granularity_quantization:
+                weight = self.hgq_weight(weight)
+                bias = None if bias is None else self.hgq_bias(bias)
+            else:
+                weight = self.quantizer(weight, k=torch.tensor(1.0), i=self.i_weight, f=self.f_weight, training=True)
+                bias = (
+                    None
+                    if bias is None
+                    else self.quantizer(bias, k=torch.tensor(1.0), i=self.i_bias, f=self.f_bias, training=True)
+                )
+        return weight, bias
+
+    def prune(self, weight):
+        if self.enable_pruning:
+            weight = self.pruning_layer(weight)
+        return weight
+
+    def prune_and_quantize(self, weight, bias):
+        if self.pruning_first:
+            weight = self.prune(weight)
+            weight, bias = self.quantize(weight, bias)
+        else:
+            weight, bias = self.quantize(weight, bias)
+            weight = self.prune(weight)
+        return weight, bias
+
+    def forward(self, x):
+        weight, bias = self.prune_and_quantize(self.weight, self.bias)
+        if self.pruning_method == "wanda":
+            self.pruning_layer.collect_input(x, self.weight, self.training)
+        x = F.linear(x, weight, bias)
+        if self.pruning_method == "activation_pruning":
+            self.pruning_layer.collect_output(x, self.training)
+        return x
+
+
+class CompressedLayerConv2d(nn.Module):
+    def __init__(self, config, layer):
+        super().__init__()
+        self.f_weight = torch.tensor(config["quantization_parameters"]["default_fractional_bits"])
+        self.i_weight = torch.tensor(config["quantization_parameters"]["default_integer_bits"])
+        self.f_bias = torch.tensor(config["quantization_parameters"]["default_fractional_bits"])
+        self.i_bias = torch.tensor(config["quantization_parameters"]["default_integer_bits"])
+        self.pruning_layer = get_pruning_layer(config=config, layer_type="conv")
+        self.pruning_method = config["pruning_parameters"]["pruning_method"]
+        overflow = "SAT_SYM" if config["quantization_parameters"]["use_symmetric_quantization"] else "SAT"
+        self.quantizer = get_fixed_quantizer(overflow_mode=overflow)
+        self.weight = nn.Parameter(layer.weight.clone())
+        self.init_weight = self.weight.clone()
+        if config["quantization_parameters"]["use_high_granularity_quantization"]:
+            self.hgq_weight = Quantizer(
+                k0=1.0,
+                i0=self.i_weight,
+                f0=self.f_weight,
+                round_mode="RND",
+                overflow_mode=overflow,
+                q_type="kif",
+                homogeneous_axis=(),
+            )
+            self.hgq_weight.build(self.weight.shape)
+            if layer.bias is not None:
+                self.hgq_bias = Quantizer(
+                    k0=1.0,
+                    i0=self.i_bias,
+                    f0=self.f_bias,
+                    round_mode="RND",
+                    overflow_mode=overflow,
+                    q_type="kif",
+                    homogeneous_axis=(),
+                )
+                self.hgq_bias.build(layer.bias.shape)
+            self.hgq_gamma = config["quantization_parameters"]["hgq_gamma"]
+
+        self.bias = nn.Parameter(layer.bias.clone()) if layer.bias is not None else None
+        self.stride = layer.stride
+        self.dilation = layer.dilation
+        self.padding = layer.padding
+        self.groups = layer.groups
+        self.in_channels = layer.in_channels
+        self.out_channels = layer.out_channels
+        self.kernel_size = layer.kernel_size
+        self.padding_mode = layer.padding_mode
+        self.pruning_first = config["training_parameters"]["pruning_first"]
+        self.enable_quantization = config["quantization_parameters"]["enable_quantization"]
+        self.use_high_granularity_quantization = config["quantization_parameters"]["use_high_granularity_quantization"]
+        self.enable_pruning = config["pruning_parameters"]["enable_pruning"]
+
+    def save_weights(self):
+        self.init_weight = self.weight.clone()
+
+    def rewind_weights(self):
+        self.weight.data = self.init_weight.clone()
+
+    def hgq_loss(self):
+        if self.pruning_layer.is_pretraining:
+            return 0.0
+        loss = (torch.sum(self.hgq_weight.quantizer.i) + torch.sum(self.hgq_weight.quantizer.f)) * self.hgq_gamma
+        if self.bias is not None:
+            loss += (torch.sum(self.hgq_bias.quantizer.i) + torch.sum(self.hgq_bias.quantizer.f)) * self.hgq_gamma
+        return loss
+
+    def quantize(self, weight, bias):
+        if self.enable_quantization:
+            if self.use_high_granularity_quantization:
+                weight = self.hgq_weight(weight)
+                bias = None if bias is None else self.hgq_bias(bias)
+            else:
+                weight = self.quantizer(weight, k=torch.tensor(1.0), i=self.i_weight, f=self.f_weight, training=True)
+                bias = (
+                    None
+                    if bias is None
+                    else self.quantizer(bias, k=torch.tensor(1.0), i=self.i_bias, f=self.f_bias, training=True)
+                )
+        return weight, bias
+
+    def prune(self, weight):
+        if self.enable_pruning:
+            weight = self.pruning_layer(weight)
+        return weight
+
+    def prune_and_quantize(self, weight, bias):
+        if self.pruning_first:
+            weight = self.prune(weight)
+            weight, bias = self.quantize(weight, bias)
+        else:
+            weight, bias = self.quantize(weight, bias)
+            weight = self.prune(weight)
+        return weight, bias
+
+    def forward(self, x):
+        weight, bias = self.prune_and_quantize(self.weight, self.bias)
+        if self.pruning_method == "wanda":
+            self.pruning_layer.collect_input(x, weight, self.training)
+        x = F.conv2d(
+            input=x,
+            weight=weight,
+            bias=bias,
+            stride=self.stride,
+            padding=self.padding,
+            dilation=self.dilation,
+            groups=self.groups,
+        )
+        if self.pruning_method == "activation_pruning":
+            self.pruning_layer.collect_output(x, self.training)
+        return x
+
+
+class CompressedLayerConv1d(nn.Module):
+    def __init__(self, config, layer):
+        super().__init__()
+        self.f_weight = torch.tensor(config["quantization_parameters"]["default_fractional_bits"])
+        self.i_weight = torch.tensor(config["quantization_parameters"]["default_integer_bits"])
+        self.f_bias = torch.tensor(config["quantization_parameters"]["default_fractional_bits"])
+        self.i_bias = torch.tensor(config["quantization_parameters"]["default_integer_bits"])
+        self.pruning_layer = get_pruning_layer(config=config, layer_type="conv")
+        self.pruning_method = config["pruning_parameters"]["pruning_method"]
+        overflow = "SAT_SYM" if config["quantization_parameters"]["use_symmetric_quantization"] else "SAT"
+        self.quantizer = get_fixed_quantizer(overflow_mode=overflow)
+        self.weight = nn.Parameter(layer.weight.clone())
+        self.init_weight = self.weight.clone()
+        if config["quantization_parameters"]["use_high_granularity_quantization"]:
+            self.hgq_weight = Quantizer(
+                k0=1.0,
+                i0=self.i_weight,
+                f0=self.f_weight,
+                round_mode="RND",
+                overflow_mode=overflow,
+                q_type="kif",
+                homogeneous_axis=(),
+            )
+            self.hgq_weight.build(self.weight.shape)
+            if layer.bias is not None:
+                self.hgq_bias = Quantizer(
+                    k0=1.0,
+                    i0=self.i_bias,
+                    f0=self.f_bias,
+                    round_mode="RND",
+                    overflow_mode=overflow,
+                    q_type="kif",
+                    homogeneous_axis=(),
+                )
+                self.hgq_bias.build(layer.bias.shape)
+            self.hgq_gamma = config["quantization_parameters"]["hgq_gamma"]
+
+        self.bias = nn.Parameter(layer.bias.clone()) if layer.bias is not None else None
+        self.stride = layer.stride
+        self.dilation = layer.dilation
+        self.padding = layer.padding
+        self.groups = layer.groups
+        self.in_channels = layer.in_channels
+        self.out_channels = layer.out_channels
+        self.kernel_size = layer.kernel_size
+        self.padding_mode = layer.padding_mode
+        self.pruning_first = config["training_parameters"]["pruning_first"]
+        self.enable_quantization = config["quantization_parameters"]["enable_quantization"]
+        self.use_high_granularity_quantization = config["quantization_parameters"]["use_high_granularity_quantization"]
+        self.enable_pruning = config["pruning_parameters"]["enable_pruning"]
+
+    def save_weights(self):
+        self.init_weight = self.weight.clone()
+
+    def rewind_weights(self):
+        self.weight.data = self.init_weight.clone()
+
+    def hgq_loss(self):
+        if self.pruning_layer.is_pretraining:
+            return 0.0
+        loss = (torch.sum(self.hgq_weight.quantizer.i) + torch.sum(self.hgq_weight.quantizer.f)) * self.hgq_gamma
+        if self.bias is not None:
+            loss += (torch.sum(self.hgq_bias.quantizer.i) + torch.sum(self.hgq_bias.quantizer.f)) * self.hgq_gamma
+        return loss
+
+    def quantize(self, weight, bias):
+        if self.enable_quantization:
+            if self.use_high_granularity_quantization:
+                weight = self.hgq_weight(weight)
+                bias = None if bias is None else self.hgq_bias(bias)
+            else:
+                weight = self.quantizer(weight, k=torch.tensor(1.0), i=self.i_weight, f=self.f_weight, training=True)
+                bias = (
+                    None
+                    if bias is None
+                    else self.quantizer(bias, k=torch.tensor(1.0), i=self.i_bias, f=self.f_bias, training=True)
+                )
+        return weight, bias
+
+    def prune(self, weight):
+        if self.enable_pruning:
+            weight = self.pruning_layer(weight)
+        return weight
+
+    def prune_and_quantize(self, weight, bias):
+        if self.pruning_first:
+            weight = self.prune(weight)
+            weight, bias = self.quantize(weight, bias)
+        else:
+            weight, bias = self.quantize(weight, bias)
+            weight = self.prune(weight)
+        return weight, bias
+
+    def forward(self, x):
+        weight, bias = self.prune_and_quantize(self.weight, self.bias)
+        if self.pruning_method == "wanda":
+            self.pruning_layer.collect_input(x, self.weight, self.training)
+        x = F.conv1d(
+            input=x,
+            weight=weight,
+            bias=bias,
+            stride=self.stride,
+            padding=self.padding,
+            dilation=self.dilation,
+            groups=self.groups,
+        )
+        if self.pruning_method == "activation_pruning":
+            self.pruning_layer.collect_output(x, self.training)
+        return x
+
+
+def add_compression_layers_torch(model, config, input_shape):
+    model = add_quantized_activations_to_model_layer(model, config)
+    # model = add_quantized_activations_to_model_functional(model, config)
+    model = add_pruning_to_model(model, config)
+    model = disable_pruning_from_layers(model, config)
+    model = add_layer_specific_quantization_to_model(model, config)
+    model(torch.rand(input_shape, device=next(model.parameters()).device))
+    return model
+
+
+def add_layer_specific_quantization_to_model(module, config):
+    for name, layer in module.named_modules():
+        if layer.__class__ in [CompressedLayerLinear, CompressedLayerConv2d, CompressedLayerConv1d]:
+            if name in config["quantization_parameters"]["layer_specific"]:
+                if "weight" in config["quantization_parameters"]["layer_specific"][name]:
+                    weight_int_bits = config["quantization_parameters"]["layer_specific"][name]["weight"]["integer_bits"]
+                    weight_fractional_bits = config["quantization_parameters"]["layer_specific"][name]["weight"][
+                        "fractional_bits"
+                    ]
+                    layer.i_weight = torch.tensor(weight_int_bits)
+                    layer.f_weight = torch.tensor(weight_fractional_bits)
+                if "bias" in config["quantization_parameters"]["layer_specific"][name]:
+                    bias_int_bits = config["quantization_parameters"]["layer_specific"][name]["bias"]["integer_bits"]
+                    bias_fractional_bits = config["quantization_parameters"]["layer_specific"][name]["bias"][
+                        "fractional_bits"
+                    ]
+                    layer.i_bias = torch.tensor(bias_int_bits)
+                    layer.f_bias = torch.tensor(bias_fractional_bits)
+    return module
+
+
+def add_quantized_activations_to_model_layer(module, config):
+    if not config["quantization_parameters"]["enable_quantization"]:
+        return module
+    # Replaces ReLU and Tanh layers with quantized versions
+    for name, layer in module.named_children():
+        i = config["quantization_parameters"]["default_integer_bits"]
+        f = config["quantization_parameters"]["default_fractional_bits"]
+        if layer.__class__ in [nn.ReLU]:
+            if name in config["quantization_parameters"]["layer_specific"]:
+                i = config["quantization_parameters"]["layer_specific"][name]["integer_bits"]
+                f = config["quantization_parameters"]["layer_specific"][name]["fractional_bits"]
+            else:
+                # For ReLU, if using default values, add 1 bit since values are unsigned.
+                # Otherwise user provides bits. TODO: Find better way to do this
+                f = config["quantization_parameters"]["default_fractional_bits"] + 1
+            relu = QuantizedReLU(config, i=i, f=f)
+            setattr(module, name, relu)
+        elif layer.__class__ in [nn.Tanh]:
+            if name in config["quantization_parameters"]["layer_specific"]:
+                f = config["quantization_parameters"]["layer_specific"][name]["fractional_bits"]
+            tanh = QuantizedTanh(config, i=i, f=f)
+            setattr(module, name, tanh)
+        else:
+            layer = add_quantized_activations_to_model_layer(layer, config)
+    return module
+
+
+def add_quantized_activations_to_model_functional(module, config):
+    # Currently not in use. TODO: Fix this
+    if config["quantization_parameters"]["use_high_granularity_quantization"]:
+        return module
+    # Replaces functional activation calls with quantized versions
+    traced_model = symbolic_trace(module)
+    for node in traced_model.graph.nodes:
+        if node.op in ["call_method", "call_function"] and (node.target == "tanh" or "function relu" in str(node.target)):
+            with traced_model.graph.inserting_after(node):
+                if node.name in config["quantization_parameters"]["layer_specific"]:
+                    bits = config["quantization_parameters"]["layer_specific"][node.name]["bits"]
+                else:
+                    bits = (
+                        config["quantization_parameters"]["default_integer_bits"]
+                        + config["quantization_parameters"]["default_fractional_bits"]
+                        + 1
+                    )  # 1 sign bit
+                kwargs = {"bits": bits}
+                if node.target == "tanh":
+                    kwargs["use_real_tanh"] = config["quantization_parameters"]["use_real_tanh"]
+                    kwargs["use_symmetric"] = config["quantization_parameters"]["use_symmetric_quantization"]
+                    # new_node = traced_model.graph.call_function(quantized_tanh, node.args, kwargs)
+                else:
+                    kwargs = {"integer_bits": config["quantization_parameters"]["default_integer_bits"], "bits": bits}
+                    # new_node = traced_model.graph.call_function(quantized_relu, node.args, kwargs)
+                # node.replace_all_uses_with(new_node)
+            traced_model.graph.erase_node(node)
+
+    traced_model.graph.lint()
+    traced_model.recompile()
+    return traced_model
+
+
+def disable_pruning_from_layers(module, config):
+    for name, layer in module.named_modules():
+        enable_pruning = name not in config["pruning_parameters"]["disable_pruning_for_layers"]
+        if layer.__class__ in [CompressedLayerLinear, CompressedLayerConv2d, CompressedLayerConv1d] and not enable_pruning:
+            layer.enable_pruning = enable_pruning
+    return module
+
+
+def add_pruning_to_model(module, config):
+    for name, layer in module.named_children():
+        if layer.__class__ is nn.Linear:
+            sparse_layer = CompressedLayerLinear(config, layer)
+            sparse_layer.pruning_layer.build(layer.weight.shape)
+            setattr(module, name, sparse_layer)
+        elif layer.__class__ is nn.Conv2d:
+            sparse_layer = CompressedLayerConv2d(config, layer)
+            sparse_layer.pruning_layer.build(layer.weight.shape)
+            setattr(module, name, sparse_layer)
+        elif layer.__class__ is nn.Conv1d:
+            sparse_layer = CompressedLayerConv1d(config, layer)
+            sparse_layer.pruning_layer.build(layer.weight.shape)
+            setattr(module, name, sparse_layer)
+        else:
+            add_pruning_to_model(layer, config)
+    return module
+
+
+def remove_pruning_from_model_torch(module, config):
+    for name, layer in module.named_children():
+        if isinstance(layer, CompressedLayerLinear):
+            if config["pruning_parameters"]["pruning_method"] == "pdp":  # Find better solution later
+                if config["training_parameters"]["pruning_first"]:
+                    weight = layer.pruning_layer.get_hard_mask(layer.weight) * layer.weight
+                    weight, bias = layer.quantize(weight, layer.bias)
+                else:
+                    weight, bias = layer.quantize(layer.weight, layer.bias)
+                    weight = layer.pruning_layer.get_hard_mask(weight) * weight
+            else:
+                weight, bias = layer.prune_and_quantize(layer.weight, layer.bias)
+            out_features = layer.out_features
+            bias_values = bias
+            in_features = layer.in_features
+            bias = True if bias_values is not None else False
+            setattr(module, name, nn.Linear(in_features=in_features, out_features=out_features, bias=bias))
+            getattr(module, name).weight.data.copy_(weight)
+            if getattr(module, name).bias is not None:
+                getattr(module, name).bias.data.copy_(bias_values.data)
+        elif isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d)):
+            if config["pruning_parameters"]["pruning_method"] == "pdp":  # Find better solution later
+                if config["training_parameters"]["pruning_first"]:
+                    weight = layer.pruning_layer.get_hard_mask(layer.weight) * layer.weight
+                    weight, bias = layer.quantize(weight, layer.bias)
+                else:
+                    weight, bias = layer.quantize(layer.weight, layer.bias)
+                    weight = layer.pruning_layer.get_hard_mask(weight) * weight
+            else:
+                weight, bias = layer.prune_and_quantize(layer.weight, layer.bias)
+            bias_values = bias
+            bias = True if bias_values is not None else False
+            conv = nn.Conv2d if isinstance(layer, CompressedLayerConv2d) else nn.Conv1d
+            setattr(
+                module,
+                name,
+                conv(
+                    layer.in_channels,
+                    layer.out_channels,
+                    layer.kernel_size,
+                    layer.stride,
+                    layer.padding,
+                    layer.dilation,
+                    layer.groups,
+                    bias,
+                    layer.padding_mode,
+                ),
+            )
+            getattr(module, name).weight.data.copy_(weight)
+            if getattr(module, name).bias is not None:
+                getattr(module, name).bias.data.copy_(bias_values.data)
+        else:
+            remove_pruning_from_model_torch(layer, config)
+    return module
+
+
+def call_post_round_functions(model, rewind, rounds, r):
+    if rewind == "round":
+        rewind_weights_functions(model)
+    elif rewind == "post-ticket-search" and r == rounds - 1:
+        rewind_weights_functions(model)
+    else:
+        post_round_functions(model)
+
+
+def post_epoch_functions(model, epoch, total_epochs, **kwargs):
+    for layer in model.modules():
+        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
+            layer.pruning_layer.post_epoch_function(epoch, total_epochs, **kwargs)
+
+
+def pre_epoch_functions(model, epoch, total_epochs):
+    for layer in model.modules():
+        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
+            layer.pruning_layer.pre_epoch_function(epoch, total_epochs)
+
+
+def post_round_functions(model):
+    for layer in model.modules():
+        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
+            layer.pruning_layer.post_round_function()
+
+
+def save_weights_functions(model):
+    for layer in model.modules():
+        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
+            layer.save_weights()
+
+
+def rewind_weights_functions(model):
+    for layer in model.modules():
+        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
+            layer.rewind_weights()
+
+
+def pre_finetune_functions(model):
+    for layer in model.modules():
+        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
+            layer.pruning_layer.pre_finetune_function()
+
+
+def post_pretrain_functions(model, config):
+    for layer in model.modules():
+        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
+            layer.pruning_layer.post_pre_train_function()
+        elif isinstance(layer, (QuantizedReLU, QuantizedTanh)):
+            layer.post_pre_train_function()
+    if config["pruning_parameters"]["pruning_method"] == "pdp" or config["pruning_parameters"]["pruning_method"] == "wanda":
+        pdp_setup(model, config)
+
+
+def pdp_setup(model, config):
+    """
+    Calculates a global sparsity threshold. Initializes target sparsity for each layer, which depends on
+    how large percentage of weights in the layer is smaller than the global threshold
+    """
+    global_weights = None
+    for layer in model.modules():
+        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
+            if global_weights is None:
+                global_weights = layer.weight.flatten()
+            else:
+                global_weights = torch.concat((global_weights, layer.weight.flatten()))
+
+    abs_global_weights = torch.abs(global_weights)
+    global_weight_topk, _ = torch.topk(abs_global_weights, abs_global_weights.numel())
+    threshold = global_weight_topk[int((1 - config["pruning_parameters"]["sparsity"]) * global_weight_topk.numel())]
+    global_weights_below_threshold = torch.where(abs_global_weights < threshold, 1, 0)
+    idx = 0
+    for layer in model.modules():
+        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
+            weight_size = layer.weight.numel()
+            w = torch.sum(global_weights_below_threshold[idx : idx + weight_size])
+            layer.pruning_layer.init_r = w / weight_size
+            layer.pruning_layer.sparsity = w / weight_size  # Wanda
+            idx += weight_size
+
+
+@torch.no_grad
+def get_layer_keep_ratio_torch(model):
+    total_w = 0
+    remaining_weights = 0
+    for layer in model.modules():
+        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
+            if layer.pruning_first:
+                weight = layer.pruning_layer.get_hard_mask(layer.weight) * layer.weight
+                weight, bias = layer.quantize(weight, layer.bias)
+                total_w += weight.numel()
+                rem = torch.count_nonzero(weight)
+                remaining_weights += rem
+            else:
+                weight, bias = layer.quantize(layer.weight, layer.bias)
+                weight = layer.pruning_layer.get_hard_mask(weight) * weight
+                total_w += weight.numel()
+                rem = torch.count_nonzero(weight)
+                remaining_weights += rem
+        elif isinstance(layer, (nn.Conv2d, nn.Conv1d, nn.Linear)):
+            total_w += layer.weight.numel()
+            remaining_weights += torch.count_nonzero(layer.weight)
+    if total_w != 0:
+        return remaining_weights / total_w
+    return 0.0
+
+
+def get_model_losses_torch(model, losses):
+    for layer in model.modules():
+        if isinstance(layer, (CompressedLayerConv2d, CompressedLayerConv1d, CompressedLayerLinear)):
+            loss = layer.pruning_layer.calculate_additional_loss()
+            if layer.use_high_granularity_quantization:
+                loss += layer.hgq_loss()
+            losses += loss
+        elif isinstance(layer, (QuantizedReLU, QuantizedTanh)):
+            if layer.use_high_granularity_quantization:
+                losses += layer.hgq_loss()
+    return losses
+
+
+def create_default_layer_quantization_pruning_config(model):
+    config = {"layer_specific": {}, "disable_pruning_for_layers": []}
+    for name, layer in model.named_modules():
+        if layer.__class__ in [nn.Linear, nn.Conv1d, nn.Conv2d]:
+            if layer.bias is None:
+                config["layer_specific"][name] = {"weight": {"integer_bits": 0, "fractional_bits": 7}}
+            else:
+                config["layer_specific"][name] = {
+                    "weight": {"integer_bits": 0, "fractional_bits": 7},
+                    "bias": {"integer_bits": 0, "fractional_bits": 7},
+                }
+            config["disable_pruning_for_layers"].append(name)
+        elif layer.__class__ in [nn.Tanh, nn.ReLU]:
+            config["layer_specific"][name] = {"integer_bits": 0, "fractional_bits": 7}
+    traced_model = symbolic_trace(model)
+    for node in traced_model.graph.nodes:
+        if node.op == "call_method" and node.target == "tanh":
+            config["layer_specific"][node.name] = {"bits": 8}
+        elif node.op == "call_function" and "function relu" == str(node.target):
+            config["layer_specific"][node.name] = {"bits": 8}
+    return config
+
+
+def add_default_layer_quantization_pruning_to_config_torch(config, model):
+    custom_scheme = create_default_layer_quantization_pruning_config(model)
+    config["quantization_parameters"]["layer_specific"] = custom_scheme["layer_specific"]
+    config["pruning_parameters"]["disable_pruning_for_layers"] = custom_scheme["disable_pruning_for_layers"]
+    return config

--- a/src/pquant/core/torch_impl/compressed_layers_torch.py
+++ b/src/pquant/core/torch_impl/compressed_layers_torch.py
@@ -603,7 +603,7 @@ def get_layer_keep_ratio_torch(model):
                 total_w += weight.numel()
                 rem = torch.count_nonzero(weight)
                 remaining_weights += rem
-        elif isinstance(layer, (nn.Conv2d, nn.Conv1d, nn.Linear)):
+        elif layer.__class__ in (nn.Conv2d, nn.Conv1d, nn.Linear):
             total_w += layer.weight.numel()
             remaining_weights += torch.count_nonzero(layer.weight)
     if total_w != 0:

--- a/src/pquant/core/torch_impl/train_torch.py
+++ b/src/pquant/core/torch_impl/train_torch.py
@@ -25,7 +25,7 @@ def iterative_train_torch(model, config, train_func, valid_func, **kwargs):
             valid_func(model, epoch=epoch, **kwargs)
             post_epoch_functions(model, e, training_config["pretraining_epochs"])
             epoch += 1
-        post_pretrain_functions(model, config)
+    post_pretrain_functions(model, config)
     for r in range(training_config["rounds"]):
         for e in range(training_config["epochs"]):
             model.train()

--- a/src/pquant/core/torch_impl/train_torch.py
+++ b/src/pquant/core/torch_impl/train_torch.py
@@ -1,0 +1,51 @@
+import torch
+
+from pquant.core.torch_impl.compressed_layers_torch import (
+    call_post_round_functions,
+    post_epoch_functions,
+    post_pretrain_functions,
+    pre_epoch_functions,
+    pre_finetune_functions,
+    save_weights_functions,
+)
+
+
+def iterative_train_torch(model, config, train_func, valid_func, **kwargs):
+    """
+    Generic training loop, user provides training and validation functions
+    """
+    epoch = torch.tensor(0)  # Keeps track of all the epochs completed
+    training_config = config["training_parameters"]
+    if training_config["pretraining_epochs"] > 0:
+        for e in range(training_config["pretraining_epochs"]):
+            model.train()
+            pre_epoch_functions(model, e, training_config["pretraining_epochs"])
+            train_func(model, epoch=epoch, **kwargs)
+            model.eval()
+            valid_func(model, epoch=epoch, **kwargs)
+            post_epoch_functions(model, e, training_config["pretraining_epochs"])
+            epoch += 1
+        post_pretrain_functions(model, config)
+    for r in range(training_config["rounds"]):
+        for e in range(training_config["epochs"]):
+            model.train()
+            if r == 0 and training_config["save_weights_epoch"] == e:
+                save_weights_functions(model)
+            pre_epoch_functions(model, e, training_config["epochs"])
+            train_func(model, epoch=epoch, **kwargs)
+            model.eval()
+            valid_func(model, epoch=epoch, **kwargs)
+            post_epoch_functions(model, e, training_config["epochs"])
+            epoch += 1
+        call_post_round_functions(model, training_config["rewind"], training_config["rounds"], r)
+    pre_finetune_functions(model)
+    if training_config["fine_tuning_epochs"] > 0:
+        for e in range(training_config["fine_tuning_epochs"]):
+            model.train()
+            pre_epoch_functions(model, e, training_config["fine_tuning_epochs"])
+            train_func(model, epoch=epoch, **kwargs)
+            model.eval()
+            valid_func(model, epoch=epoch, **kwargs)
+            post_epoch_functions(model, e, training_config["fine_tuning_epochs"])
+            epoch += 1
+    return model

--- a/src/pquant/core/train.py
+++ b/src/pquant/core/train.py
@@ -1,61 +1,12 @@
-import torch
-
-from pquant.core.compressed_layers import (
-    add_pruning_and_quantization,
-    call_post_round_functions,
-    post_epoch_functions,
-    post_pretrain_functions,
-    pre_epoch_functions,
-    pre_finetune_functions,
-    remove_pruning_from_model,
-    save_weights_functions,
-)
-
-
-def train_compressed_model(model, config, train_func, valid_func, **kwargs):
-    # Adds pruning and quantization layers, trains model, then removes pruning layers and returns the model
-    model = add_pruning_and_quantization(model, config)
-    model = iterative_train(model, config, train_func, valid_func, **kwargs)
-    model = remove_pruning_from_model(model, config)
-    return model
+import keras
 
 
 def iterative_train(model, config, train_func, valid_func, **kwargs):
-    """
-    Generic training loop, user provides training and validation functions
-    """
-    epoch = torch.tensor(0)  # Keeps track of all the epochs completed
-    training_config = config["training_parameters"]
-    if training_config["pretraining_epochs"] > 0:
-        for e in range(training_config["pretraining_epochs"]):
-            model.train()
-            pre_epoch_functions(model, e, training_config["pretraining_epochs"])
-            train_func(model, epoch=epoch, **kwargs)
-            model.eval()
-            valid_func(model, epoch=epoch, **kwargs)
-            post_epoch_functions(model, e, training_config["pretraining_epochs"])
-            epoch += 1
-        post_pretrain_functions(model, config)
-    for r in range(training_config["rounds"]):
-        for e in range(training_config["epochs"]):
-            model.train()
-            if r == 0 and training_config["save_weights_epoch"] == e:
-                save_weights_functions(model)
-            pre_epoch_functions(model, e, training_config["epochs"])
-            train_func(model, epoch=epoch, **kwargs)
-            model.eval()
-            valid_func(model, epoch=epoch, **kwargs)
-            post_epoch_functions(model, e, training_config["epochs"])
-            epoch += 1
-        call_post_round_functions(model, training_config["rewind"], training_config["rounds"], r)
-    pre_finetune_functions(model)
-    if training_config["fine_tuning_epochs"] > 0:
-        for e in range(training_config["fine_tuning_epochs"]):
-            model.train()
-            pre_epoch_functions(model, e, training_config["fine_tuning_epochs"])
-            train_func(model, epoch=epoch, **kwargs)
-            model.eval()
-            valid_func(model, epoch=epoch, **kwargs)
-            post_epoch_functions(model, e, training_config["fine_tuning_epochs"])
-            epoch += 1
-    return model
+    if keras.backend.backend() == "torch":
+        from pquant.core.torch_impl.train_torch import iterative_train_torch
+
+        return iterative_train_torch(model, config, train_func, valid_func, **kwargs)
+    else:
+        from pquant.core.tf_impl.train_tf import iterative_train_tf
+
+        return iterative_train_tf(model, config, train_func, valid_func, **kwargs)

--- a/src/pquant/core/utils.py
+++ b/src/pquant/core/utils.py
@@ -10,31 +10,31 @@ from pquant.pruning_methods.pdp import PDP
 from pquant.pruning_methods.wanda import Wanda
 
 
-def get_pruning_layer(config, layer, out_size):
+def get_pruning_layer(config, layer_type):
     pruning_method = config["pruning_parameters"]["pruning_method"]
     if pruning_method == "dst":
-        return DST(config, layer, out_size)
+        return DST(config, layer_type)
     elif pruning_method == "autosparse":
-        return AutoSparse(config, layer, out_size)
+        return AutoSparse(config, layer_type)
     elif pruning_method == "cs":
-        return ContinuousSparsification(config, layer, out_size)
+        return ContinuousSparsification(config, layer_type)
     elif pruning_method == "pdp":
-        return PDP(config, layer, out_size)
-    elif pruning_method == "continual_learning":
-        return ActivationPruning(config, layer, out_size)
+        return PDP(config, layer_type)
+    elif pruning_method == "activation_pruning":
+        return ActivationPruning(config, layer_type)
     elif pruning_method == "wanda":
-        return Wanda(config, layer, out_size)
+        return Wanda(config, layer_type)
 
 
 def get_default_config(pruning_method: str):
     assert pruning_method in [
         "autosparse",
-        "cl",
+        "ap",
         "cs",
         "dst",
         "pdp",
         "wanda",
-    ], "Unkown pruning method. Acceptable pruning methods: autosparse, cl, cs, dst, pdp, wanda"
+    ], "Unkown pruning method. Acceptable pruning methods: autosparse, ap, cs, dst, pdp, wanda"
     yaml_name = f"config_{pruning_method}.yaml"
     parent = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     path = os.path.join(parent, "configs", yaml_name)
@@ -95,7 +95,7 @@ def validate_pruning_parameters(config):
             "threshold_decay",
             "structured_pruning",
         ]
-    elif pruning_method == "continual_learning":
+    elif pruning_method == "activation_pruning":
         valid_keys = [
             "disable_pruning_for_layers",
             "enable_pruning",

--- a/src/pquant/pruning_methods/activation_pruning.py
+++ b/src/pquant/pruning_methods/activation_pruning.py
@@ -1,59 +1,63 @@
-import torch
-import torch.nn as nn
+import keras
+from keras import ops
 
 
-class ActivationPruning(nn.Module):
+class ActivationPruning(keras.layers.Layer):
 
-    def __init__(self, config, layer, out_size, *args, **kwargs):
+    def __init__(self, config, layer_type, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.config = config
         self.act_type = "relu"
         self.t = 0
-        self.layer_type = "linear" if isinstance(layer, nn.Linear) else "conv"
-        self.shape = (layer.weight.shape[0], 1)
-        if self.layer_type == "conv":
-            self.shape = (layer.weight.shape[0], 1, 1, 1)
-        self.mask = torch.ones(self.shape, requires_grad=False).to(layer.weight.device)
+        self.layer_type = layer_type
         self.activations = None
         self.total = 0.0
         self.is_pretraining = True
+        self.done = False
+        self.threshold = ops.convert_to_tensor(config["pruning_parameters"]["threshold"])
 
-    def collect_output(self, output):
+    def build(self, input_shape):
+        self.shape = (input_shape[0], 1)
+        if self.layer_type == "conv":
+            self.shape = (input_shape[0], 1, 1, 1)
+        self.mask = ops.ones(self.shape)
+
+    def collect_output(self, output, training):
         """
         Accumulates values for how often the outputs of the neurons and channels of
         linear/convolution layer are over 0. Every t_delta steps, uses these values to update
         the mask to prune those channels and neurons that are active less than a given threshold
         """
-        if not self.training or self.is_pretraining:
+        if self.done or not training or self.is_pretraining:
             # Don't collect during validation
             return
         if self.activations is None:
             # Initialize activations dynamically
-            self.activations = torch.zeros(size=output.shape[1:], dtype=output.dtype, device=self.mask.device)
+            self.activations = ops.zeros(shape=output.shape[1:], dtype=output.dtype)
         self.t += 1
         self.total += output.shape[0]
-        gt_zero = (output > 0).float()
-        gt_zero = torch.sum(gt_zero, dim=0)  # Sum over batch, take average during mask update
+        gt_zero = ops.cast((output > 0), output.dtype)
+        gt_zero = ops.sum(gt_zero, axis=0)  # Sum over batch, take average during mask update
         self.activations += gt_zero
         if self.t % self.config["pruning_parameters"]["t_delta"] == 0:
             pct_active = self.activations / self.total
             self.t = 0
             self.total = 0
             if self.layer_type == "linear":
-                self.mask = (pct_active > self.config["pruning_parameters"]["threshold"]).float().unsqueeze(1)
+                self.mask = ops.expand_dims(ops.cast((pct_active > self.threshold), pct_active.dtype), 1)
             else:
                 pct_active = pct_active.view(pct_active.shape[0], -1)
-                pct_active_avg = torch.mean(pct_active, dim=-1)
-                pct_active_above_threshold = (pct_active_avg > self.config["pruning_parameters"]["threshold"]).float()
-                self.mask = (pct_active_above_threshold).unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
+                pct_active_avg = ops.mean(pct_active, axis=-1)
+                pct_active_above_threshold = ops.cast((pct_active_avg > self.threshold), pct_active_avg.dtype)
+                self.mask = ops.reshape(pct_active_above_threshold, list(pct_active_above_threshold.shape) + [1, 1, 1])
             self.activations *= 0.0
+            self.done = True
 
-    def build(self, weight):
-        # Since this is a torch layer, do nothing
-        pass
-
-    def forward(self, weight):  # Mask is only updated every t_delta step, using collect_output
+    def call(self, weight):  # Mask is only updated every t_delta step, using collect_output
         return self.mask * weight
+
+    def get_hard_mask(self, weight):
+        return self.mask
 
     def post_pre_train_function(self):
         self.is_pretraining = False

--- a/src/pquant/pruning_methods/autosparse.py
+++ b/src/pquant/pruning_methods/autosparse.py
@@ -59,6 +59,7 @@ class AutoSparse(keras.layers.Layer):
         self.config = config
         global BACKWARD_SPARSITY
         BACKWARD_SPARSITY = config["pruning_parameters"]["backward_sparsity"]
+        self.is_pretraining = True
 
     def build(self, input_shape):
         self.threshold_size = get_threshold_size(self.config, input_shape)
@@ -104,6 +105,9 @@ class AutoSparse(keras.layers.Layer):
 
     def post_round_function(self):
         pass
+
+    def post_pre_train_function(self):
+        self.is_pretraining = False
 
     def post_epoch_function(self, epoch, total_epochs):
         self.alpha *= cosine_sigmoid_decay(epoch, total_epochs)

--- a/src/pquant/pruning_methods/autosparse.py
+++ b/src/pquant/pruning_methods/autosparse.py
@@ -1,6 +1,7 @@
 import keras
 import numpy as np
 from keras import ops
+from keras.initializers import Constant
 
 pi = ops.convert_to_tensor(np.pi)
 L0 = ops.convert_to_tensor(-6.0)
@@ -19,11 +20,11 @@ def cosine_sigmoid_decay(i, T):
     return ops.maximum(cosine_decay(i, T), sigmoid_decay(i, T))
 
 
-def get_threshold_size(config, size, weight_shape):
+def get_threshold_size(config, weight_shape):
     if config["pruning_parameters"]["threshold_type"] == "layerwise":
         return (1, 1)
     elif config["pruning_parameters"]["threshold_type"] == "channelwise":
-        return (size, 1)
+        return (weight_shape[0], 1)
     elif config["pruning_parameters"]["threshold_type"] == "weightwise":
         return (weight_shape[0], np.prod(weight_shape[1:]))
 
@@ -35,8 +36,8 @@ BACKWARD_SPARSITY = False
 def autosparse_prune(x, alpha):
     mask = ops.relu(x)
     backward_sparsity = 0.5
-    x_flat = ops.reshape(x, -1)
-    k = int(ops.size(x_flat) * backward_sparsity)
+    x_flat = ops.ravel(x)
+    k = ops.cast(ops.cast(ops.size(x_flat), x.dtype) * backward_sparsity, "int32")
     topks, _ = ops.top_k(x_flat, k)
     kth_value = topks[-1]
 
@@ -52,16 +53,23 @@ def autosparse_prune(x, alpha):
 
 
 class AutoSparse(keras.layers.Layer):
-    def __init__(self, config, layer, out_size, *args, **kwargs):
+    def __init__(self, config, layer_type, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        threshold_size = get_threshold_size(config, out_size, layer.weight.shape)
-        self.threshold = self.add_weight(name="threshold", shape=threshold_size, initializer="ones", trainable=True)
-        self.threshold.assign(config["pruning_parameters"]["threshold_init"] * self.threshold)
-        self.alpha = ops.convert_to_tensor(config["pruning_parameters"]["alpha"], dtype="float32")
         self.g = ops.sigmoid
         self.config = config
         global BACKWARD_SPARSITY
         BACKWARD_SPARSITY = config["pruning_parameters"]["backward_sparsity"]
+
+    def build(self, input_shape):
+        self.threshold_size = get_threshold_size(self.config, input_shape)
+        self.threshold = self.add_weight(
+            name="threshold",
+            shape=self.threshold_size,
+            initializer=Constant(self.config["pruning_parameters"]["threshold_init"]),
+            trainable=True,
+        )
+        self.alpha = ops.convert_to_tensor(self.config["pruning_parameters"]["alpha"], dtype="float32")
+        super().build(input_shape)
 
     def call(self, weight):
         """
@@ -94,13 +102,10 @@ class AutoSparse(keras.layers.Layer):
     def pre_finetune_function(self):
         pass
 
-    def post_epoch_function(self, epoch, total_epochs, alpha_multiplier, autotune_epochs=0, writer=None, global_step=0):
-        # Decay alpha
-        if epoch >= autotune_epochs:
-            self.alpha *= cosine_sigmoid_decay(epoch - autotune_epochs, total_epochs)
-        else:
-            self.alpha *= alpha_multiplier
+    def post_round_function(self):
+        pass
+
+    def post_epoch_function(self, epoch, total_epochs):
+        self.alpha *= cosine_sigmoid_decay(epoch, total_epochs)
         if epoch == self.config["pruning_parameters"]["alpha_reset_epoch"]:
             self.alpha *= 0.0
-        if writer is not None:
-            writer.write_scalars([("Autosparse_alpha", self.alpha, global_step)])

--- a/src/pquant/pruning_methods/cs.py
+++ b/src/pquant/pruning_methods/cs.py
@@ -11,6 +11,7 @@ class ContinuousSparsification(keras.layers.Layer):
         self.final_temp = config["pruning_parameters"]["final_temp"]
         self.do_hard_mask = False
         self.mask = None
+        self.is_pretraining = True
 
     def build(self, input_shape):
         self.s_init = ops.convert_to_tensor(self.config["pruning_parameters"]["threshold_init"] * ops.ones(input_shape))
@@ -35,7 +36,7 @@ class ContinuousSparsification(keras.layers.Layer):
             return mask
 
     def post_pre_train_function(self):
-        pass
+        self.is_pretraining = False
 
     def pre_epoch_function(self, epoch, total_epochs):
         pass

--- a/src/pquant/pruning_methods/cs.py
+++ b/src/pquant/pruning_methods/cs.py
@@ -1,19 +1,22 @@
 import keras
 from keras import ops
+from keras.api.initializers import Constant
 
 
 class ContinuousSparsification(keras.layers.Layer):
-    def __init__(self, config, layer, out_size, *args, **kwargs):
+    def __init__(self, config, layer_type, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.config = config
-        self.beta = 1
-        self.s = self.add_weight(name="threshold", shape=layer.weight.shape, initializer="ones")
-        self.s.assign(config["pruning_parameters"]["threshold_init"] * self.s)
-        self.s_init = config["pruning_parameters"]["threshold_init"]
+        self.beta = 1.0
         self.final_temp = config["pruning_parameters"]["final_temp"]
-        self.init_weight = layer.weight.clone()
         self.do_hard_mask = False
         self.mask = None
+
+    def build(self, input_shape):
+        self.s_init = ops.convert_to_tensor(self.config["pruning_parameters"]["threshold_init"] * ops.ones(input_shape))
+        self.s = self.add_weight(name="threshold", shape=input_shape, initializer=Constant(self.s_init), trainable=True)
+        self.scaling = 1.0 / ops.sigmoid(self.s_init)
+        super().build(input_shape)
 
     def call(self, weight):
         self.mask = self.get_mask()
@@ -27,9 +30,8 @@ class ContinuousSparsification(keras.layers.Layer):
             mask = self.get_hard_mask()
             return mask
         else:
-            scaling = 1.0 / ops.sigmoid(self.config["pruning_parameters"]["threshold_init"])
             mask = ops.sigmoid(self.beta * self.s)
-            mask = mask * scaling
+            mask = mask * self.scaling
             return mask
 
     def post_pre_train_function(self):
@@ -41,8 +43,10 @@ class ContinuousSparsification(keras.layers.Layer):
     def post_epoch_function(self, epoch, total_epochs):
         self.beta *= self.final_temp ** (1 / (total_epochs - 1))
 
-    def get_hard_mask(self):
-        return (self.s > 0).float()
+    def get_hard_mask(self, weight=None):
+        if self.config["pruning_parameters"]["enable_pruning"]:
+            return ops.cast((self.s > 0), self.s.dtype)
+        return ops.convert_to_tensor(1.0)
 
     def post_round_function(self):
         min_beta_s_s0 = ops.minimum(self.beta * self.s, self.s_init)
@@ -50,7 +54,9 @@ class ContinuousSparsification(keras.layers.Layer):
         self.beta = 1
 
     def calculate_additional_loss(self):
-        return self.config["pruning_parameters"]["threshold_decay"] * ops.norm(ops.reshape(self.mask, -1), ord=1)
+        return ops.convert_to_tensor(
+            self.config["pruning_parameters"]["threshold_decay"] * ops.norm(ops.reshape(self.get_mask(), -1), ord=1)
+        )
 
     def get_layer_sparsity(self, weight):
         return ops.sum(self.get_hard_mask()) / ops.size(weight)

--- a/src/pquant/pruning_methods/dst.py
+++ b/src/pquant/pruning_methods/dst.py
@@ -3,11 +3,11 @@ import numpy as np
 from keras import ops
 
 
-def get_threshold_size(config, size, weight_shape):
+def get_threshold_size(config, weight_shape):
     if config["pruning_parameters"]["threshold_type"] == "layerwise":
         return (1, 1)
     elif config["pruning_parameters"]["threshold_type"] == "channelwise":
-        return (size, 1)
+        return (weight_shape[0], 1)
     elif config["pruning_parameters"]["threshold_type"] == "weightwise":
         return (weight_shape[0], np.prod(weight_shape[1:]))
 
@@ -30,12 +30,14 @@ def binary_step(weight):
 
 
 class DST(keras.layers.Layer):
-    def __init__(self, config, layer, out_size, *args, **kwargs):
+    def __init__(self, config, layer_type, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        threshold_size = get_threshold_size(config, out_size, layer.weight.shape)
-        self.threshold = self.add_weight(shape=threshold_size, initializer="zeros", trainable=True)
         self.config = config
-        self.mask = ops.ones(layer.weight.shape, requires_grad=False)
+
+    def build(self, input_shape):
+        self.threshold_size = get_threshold_size(self.config, input_shape)
+        self.threshold = self.add_weight(shape=self.threshold_size, initializer="zeros", trainable=True)
+        self.mask = ops.ones(input_shape)
 
     def call(self, weight):
         """
@@ -45,10 +47,10 @@ class DST(keras.layers.Layer):
             0             if |W| > 1
         """
         mask = self.get_mask(weight)
-        ratio = 1.0 - ops.sum(mask) / ops.size(mask)
-        if ratio >= self.config["pruning_parameters"]["max_pruning_pct"]:
-            self.threshold.assign(ops.zeros(self.threshold.shape))
-            mask = self.get_mask(weight)
+        ratio = 1.0 - ops.sum(mask) / ops.cast(ops.size(mask), mask.dtype)
+        flag = ratio >= self.config["pruning_parameters"]["max_pruning_pct"]
+        self.threshold.assign(ops.where(flag, ops.ones(self.threshold.shape), self.threshold))
+        mask = self.get_mask(weight)
         masked_weight = weight * mask
         return masked_weight
 

--- a/src/pquant/pruning_methods/dst.py
+++ b/src/pquant/pruning_methods/dst.py
@@ -33,6 +33,7 @@ class DST(keras.layers.Layer):
     def __init__(self, config, layer_type, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.config = config
+        self.is_pretraining = True
 
     def build(self, input_shape):
         self.threshold_size = get_threshold_size(self.config, input_shape)
@@ -82,7 +83,7 @@ class DST(keras.layers.Layer):
         pass
 
     def post_pre_train_function(self):
-        pass
+        self.is_pretraining = False
 
     def post_round_function(self):
         pass

--- a/src/pquant/pruning_methods/pdp.py
+++ b/src/pquant/pruning_methods/pdp.py
@@ -1,24 +1,25 @@
 import keras
-import torch.nn as nn
 from keras import ops
 
 
 class PDP(keras.layers.Layer):
-    def __init__(self, config, layer, out_size, *args, **kwargs):
+    def __init__(self, config, layer_type, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.init_r = config["pruning_parameters"]["sparsity"]
+        self.init_r = ops.convert_to_tensor(config["pruning_parameters"]["sparsity"])
+        self.epsilon = ops.convert_to_tensor(config["pruning_parameters"]["epsilon"])
         self.r = config["pruning_parameters"]["sparsity"]
         self.temp = config["pruning_parameters"]["temperature"]
         self.is_pretraining = True
         self.config = config
         self.fine_tuning = False
-        self.layer_type = "linear" if isinstance(layer, nn.Linear) else "conv"
+        self.layer_type = layer_type
 
     def build(self, input_shape):
         input_shape_concatenated = list(input_shape) + [1]
         self.softmax_shape = input_shape_concatenated
         self.t = ops.ones(input_shape_concatenated) * 0.5
         self.mask = ops.ones(input_shape)
+        self.flat_weight_size = ops.cast(ops.size(self.mask), self.mask.dtype)
         super().build(input_shape)
 
     def post_pre_train_function(self):
@@ -26,14 +27,14 @@ class PDP(keras.layers.Layer):
 
     def pre_epoch_function(self, epoch, total_epochs):
         if not self.is_pretraining:
-            self.r = ops.minimum(1.0, self.config["pruning_parameters"]["epsilon"] * (epoch + 1)) * self.init_r
+            self.r = ops.minimum(1.0, self.epsilon * (epoch + 1)) * self.init_r
 
     def post_round_function(self):
         pass
 
     def get_hard_mask(self, weight):
         if self.fine_tuning:
-            return (self.mask >= 0.5).float()
+            return self.mask
         if self.config["pruning_parameters"]["structured_pruning"]:
             if self.layer_type == "conv":
                 mask = self.get_mask_structured_channel(weight)
@@ -41,12 +42,12 @@ class PDP(keras.layers.Layer):
                 mask = self.get_mask_structured_linear(weight)
         else:
             mask = self.get_mask(weight)
-        self.mask = (mask >= 0.5).float()
-        return (mask >= 0.5).float()
+        self.mask = ops.cast((mask >= 0.5), mask.dtype)
+        return self.mask
 
     def pre_finetune_function(self):
         self.fine_tuning = True
-        self.mask = (self.mask >= 0.5).float()
+        self.mask = ops.cast((self.mask >= 0.5), self.mask.dtype)
 
     def get_mask_structured_linear(self, weight):
         """
@@ -60,7 +61,9 @@ class PDP(keras.layers.Layer):
         """ Do top_k for all neuron norms. Returns sorted array, just use the values on both
         sides of the threshold (sparsity * size(norm)) to calculate t directly """
         W_all, _ = ops.top_k(norm_flat, ops.size(norm_flat))
-        lim = ops.clip(int((1 - self.r) * ops.size(W_all)), 0, ops.size(W_all) - 2)
+        size = ops.cast(ops.size(W_all), self.mask.dtype)
+        ind = ops.cast((1 - self.r) * size, "int32")
+        lim = ops.clip(ind, 0, ops.cast(size - 2, "int32"))
 
         Wh = W_all[lim]
         Wt = W_all[lim + 1]
@@ -86,7 +89,9 @@ class PDP(keras.layers.Layer):
         """ Do top_k for all channel norms. Returns sorted array, just use the values on both
         sides of the threshold (sparsity * size(norm)) to calculate t directly """
         W_all, _ = ops.top_k(norm_flat, ops.size(norm_flat))
-        lim = ops.clip(int((1 - self.r) * ops.size(W_all)), 0, ops.size(W_all) - 2)
+        size = ops.cast(ops.size(W_all), self.mask.dtype)
+        ind = ops.cast((1 - self.r) * size, "int32")
+        lim = ops.clip(ind, 0, ops.cast(size - 2, "int32"))
 
         Wh = W_all[lim]
         Wt = W_all[lim + 1]
@@ -110,7 +115,8 @@ class PDP(keras.layers.Layer):
         """ Do top_k for all weights. Returns sorted array, just use the values on both
         sides of the threshold (sparsity * size(weight)) to calculate t directly """
         all, _ = ops.top_k(abs_weight_flat, ops.size(abs_weight_flat))
-        lim = ops.clip(int((1 - self.r) * ops.size(abs_weight_flat)), 0, ops.size(abs_weight_flat) - 2)
+        ind = ops.cast((1 - self.r) * self.flat_weight_size, "int32")
+        lim = ops.clip(ind, 0, ops.cast(self.flat_weight_size - 2, "int32"))
         Wh = all[lim]
         Wt = all[lim + 1]
         t = self.t * (Wh + Wt)
@@ -138,8 +144,7 @@ class PDP(keras.layers.Layer):
         return 0
 
     def get_layer_sparsity(self, weight):
-        mask = self.mask
-        masked_weight_rounded = (mask >= 0.5).float()
+        masked_weight_rounded = ops.cast((self.mask >= 0.5), self.mask.dtype)
         masked_weight = masked_weight_rounded * weight
         return ops.count_nonzero(masked_weight) / ops.size(masked_weight)
 

--- a/src/pquant/pruning_methods/wanda.py
+++ b/src/pquant/pruning_methods/wanda.py
@@ -1,79 +1,73 @@
-import torch
-import torch.nn as nn
+import keras
+from keras import ops
 
 
-class Wanda(nn.Module):
+class Wanda(keras.layers.Layer):
 
-    def __init__(self, config, layer, out_size, *args, **kwargs):
+    def __init__(self, config, layer_type, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.config = config
         self.act_type = "relu"
         self.t = 0
-        self.layer_type = "linear" if isinstance(layer, nn.Linear) else "conv"
-        self.mask = torch.tensor(1.0)
+        self.layer_type = layer_type
+        self.batches_collected = 0
         self.inputs = None
         self.total = 0.0
-        self.weight = layer.weight
         self.done = False
         self.sparsity = self.config["pruning_parameters"]["sparsity"]
         self.is_pretraining = True
         self.N = self.config["pruning_parameters"]["N"]
         self.M = self.config["pruning_parameters"]["M"]
-        self.t_start_collecting = self.config["pruning_parameters"]["t_start_collecting"]
+        self.t_start_collecting_batch = self.config["pruning_parameters"]["t_start_collecting_batch"]
 
-    def handle_linear(self, x):
-        norm = x.norm(p=2, dim=0)
-        metric = self.weight.abs() * norm
+    def build(self, input_shape):
+        self.mask = ops.ones(input_shape)
+        super().build(input_shape)
+
+    def get_mask(self, weight, metric, sparsity):
+        d0, d1 = metric.shape
+        keep_idxs = ops.argsort(metric, axis=1)[:, int(d1 * sparsity) :] + ops.arange(d0)[:, None] * d1
+        keep_idxs = ops.ravel(keep_idxs)
+        kept_values = ops.reshape(
+            ops.scatter(keep_idxs[:, None], ops.take(ops.ravel(weight), keep_idxs), ops.array((ops.size(weight),))),
+            weight.shape,
+        )
+        mask = ops.cast(kept_values != 0, weight.dtype)
+        return mask
+
+    def handle_linear(self, x, weight):
+        norm = ops.norm(x, ord=2, axis=0)
+        metric = ops.abs(weight) * norm
         if self.N is not None and self.M is not None:
             # N:M pruning
-            W_mask = torch.zeros_like(self.weight)
-            for ii in range(self.weight.shape[1]):
-                if ii % self.M == 0:
-                    tmp = metric.abs()[:, ii : (ii + self.M)].float()
-                    if tmp.shape[1] < self.M:
-                        continue
-                    indices = ii + torch.topk(tmp, self.N, dim=1, largest=False)[1]
-                    W_mask = torch.scatter(W_mask, 1, indices, 1)
-                    self.mask.data = W_mask.view(self.weight.shape)
+            metric_reshaped = ops.reshape(metric, (-1, self.M))
+            weight_reshaped = ops.reshape(weight, (-1, self.M))
+            mask = self.get_mask(weight_reshaped, metric_reshaped, sparsity=self.N / self.M)
+            self.mask = ops.reshape(mask, weight.shape)
         else:
             # Unstructured pruning
-            _, sorted_idx = torch.sort(metric, dim=1)
-            pruned_idx = sorted_idx[:, : int(self.weight.shape[1] * self.sparsity)]
-            self.weight.data = self.weight.data.scatter_(
-                dim=1, index=pruned_idx, src=torch.zeros(pruned_idx.shape).to(self.weight.device)
-            )
-            self.mask.data = (self.weight != 0).float()
+            self.mask = self.get_mask(weight, metric, sparsity=self.sparsity)
 
-    def handle_conv(self, x):
-        inputs_avg = torch.mean(x.view(x.shape[0], x.shape[1], -1), dim=0)
-        norm = inputs_avg.norm(p=2, dim=-1).unsqueeze(0).unsqueeze(-1).unsqueeze(-1)
-        metric = self.weight.abs() * norm
+    def handle_conv(self, x, weight):
+        inputs_avg = ops.mean(ops.reshape(x, (x.shape[0], x.shape[1], -1)), axis=0)
+        norm = ops.norm(inputs_avg, ord=2, axis=-1)
+        norm = ops.reshape(norm, [1] + list(norm.shape) + [1, 1])
+        metric = ops.abs(weight) * norm
         if self.N is not None and self.M is not None:
             # N:M pruning
-            metric = x.view(metric.shape[0], -1)
-            W_mask = torch.zeros(self.weight.shape, device=metric.device)
-            W_mask = W_mask.view(W_mask.shape[0], -1)
-            for ii in range(W_mask.shape[1]):
-                if ii % self.M == 0:
-                    tmp = metric.abs()[:, ii : (ii + self.M)].float()
-                    if tmp.shape[1] < self.M:
-                        continue
-                    n = min(self.N, W_mask.shape[1] - ii)
-                    indices = ii + torch.topk(tmp, n, dim=1, largest=False)[1]
-                    indices_limited = torch.minimum(indices, torch.tensor(W_mask.shape[1] - 1))
-                    W_mask = torch.scatter(W_mask, 1, indices_limited, 1)
-            self.mask.data = W_mask.view(self.weight.shape)
+            metric_reshaped = ops.reshape(metric, (-1, self.M))
+            weight_reshaped = ops.reshape(weight, (-1, self.M))
+            mask = self.get_mask(weight_reshaped, metric_reshaped, sparsity=self.N / self.M)
+            self.mask = ops.reshape(mask, weight.shape)
         else:
             # Unstructured pruning
-            _, sorted_idx = torch.sort(metric, dim=1)
-            pruned_idx = sorted_idx[:, : int(self.weight.shape[1] * self.sparsity)]
-            self.weight.data = self.weight.data.scatter_(
-                dim=1, index=pruned_idx, src=torch.zeros(pruned_idx.shape).to(self.weight.device)
-            )
-            self.mask.data = (self.weight != 0).float()
+            metric_reshaped = ops.reshape(metric, (metric.shape[0], -1))
+            weight_reshaped = ops.reshape(weight, (weight.shape[0], -1))
+            mask = self.get_mask(weight_reshaped, metric_reshaped, sparsity=self.sparsity)
+            self.mask = ops.reshape(mask, weight.shape)
 
-    def collect_input(self, x):
-        if self.done or self.is_pretraining:
+    def collect_input(self, x, weight, training):
+        if self.done or not training:
             return
         """
             Accumulates layer inputs starting at step t_start_collecting for t_delta steps, then averages it.
@@ -86,33 +80,28 @@ class Wanda(nn.Module):
         if self.inputs is not None:
             batch_size = self.inputs.shape[0]
             ok_batch = x.shape[0] == batch_size
-        if not self.training or not ok_batch:
+        if not training or not ok_batch:
             # Don't collect during validation
             return
-        self.t += 1
-        if self.t < self.t_start_collecting:
+        if self.t < self.t_start_collecting_batch:
             return
+        self.batches_collected += 1
         self.total += 1
-        self.inputs = x if self.inputs is None else self.inputs + x
 
-        if self.t % (self.t_start_collecting + self.config["pruning_parameters"]["t_delta"]) == 0:
+        self.inputs = x if self.inputs is None else self.inputs + x
+        if self.batches_collected % (self.config["pruning_parameters"]["t_delta"]) == 0:
             inputs_avg = self.inputs / self.total
-            self.prune(inputs_avg)
+            self.prune(inputs_avg, weight)
             self.done = True
             self.inputs = None
 
-    def prune(self, x):
+    def prune(self, x, weight):
         if self.layer_type == "linear":
-            self.handle_linear(x)
+            self.handle_linear(x, weight)
         else:
-            self.handle_conv(x)
+            self.handle_conv(x, weight)
 
-    def build(self, weight):
-        # Since this is a torch layer, do nothing
-        pass
-
-    def forward(self, weight):  # Mask is only updated every t_delta step, using collect_output
-        self.weight.data = weight
+    def call(self, weight):  # Mask is only updated every t_delta step, using collect_output
         return self.mask * weight
 
     def post_pre_train_function(self):
@@ -133,5 +122,10 @@ class Wanda(nn.Module):
     def get_layer_sparsity(self, weight):
         pass
 
+    def get_hard_mask(self, weight=None):
+        return self.mask
+
     def post_epoch_function(self, epoch, total_epochs):
+        if self.is_pretraining is False:
+            self.t += 1
         pass


### PR DESCRIPTION
Add support for TensorFlow backend.

   - Add logic to replace TF layers with compression layers, along with all the functions to train the compressed model
   - Make ActivationPruning and Wanda Keras layers. Replace torch operations in PDP with keras operations
   - Add pretraining flags to all pruning methods to enable HGQ training
   - Make Wanda and ActivationPruning start pruning at a selected batch, instead of a selected step