### PR TITLE
MDMM tests and hardware-aware metric functions

### DIFF
--- a/src/pquant/configs/config_mdmm_fpga.yaml
+++ b/src/pquant/configs/config_mdmm_fpga.yaml
@@ -1,0 +1,71 @@
+# file: /src/pquant/configs/config_mdmm_fpga.yaml
+# Hardware-aware structured pruning targeting FPGA DSP/BRAM resources.
+
+pruning_parameters:
+  pruning_method: mdmm
+  enable_pruning: true
+  disable_pruning_for_layers: []
+  constraint_type: "Equality"
+  target_value: 0.0
+  metric_type: "FPGAAwareSparsity"
+  target_sparsity: 0.9
+  rf: 4
+  epsilon: 1.0e-03
+  scale: 50.0
+  damping: 1.0
+  use_grad: false
+  constraint_lr: 1.0e-3
+  # FPGAAwareSparsityMetric-specific
+  precision: 16
+  target_resource: "DSP"   # "DSP" or "BRAM"
+  bram_width: 36
+
+quantization_parameters:
+  enable_quantization: true
+  default_weight_keep_negatives: 1.
+  default_weight_integer_bits: 0.
+  default_weight_fractional_bits: 7.
+  default_data_keep_negatives: 0.
+  default_data_integer_bits: 0.
+  default_data_fractional_bits: 7.
+  granularity: "per_tensor"
+  quantize_input: true
+  quantize_output: false
+  hgq_beta: 1e-5
+  hgq_gamma: 0.0003
+  hgq_heterogeneous: True
+  layer_specific: {}
+  use_high_granularity_quantization: false
+  use_real_tanh: false
+  use_relu_multiplier: false
+  use_symmetric_quantization: false
+  overflow_mode_parameters: SAT
+  overflow_mode_data: SAT
+  round_mode: RND
+training_parameters:
+  epochs: 200
+  fine_tuning_epochs: 30
+  pretraining_epochs: 0
+  pruning_first: true
+  rewind: never
+  rounds: 1
+  save_weights_epoch: -1
+fitcompress_parameters:
+  enable_fitcompress : false
+  optimize_quantization : true
+  quantization_schedule : [7.,4.,3.,2]
+  pruning_schedule : {start : 0, end : -3, steps : 40}
+  compression_goal : 0.10
+  optimize_pruning : false
+  greedy_astar : true
+  approximate : true
+  f_lambda : 1
+hpo_parameters:
+    experiment_name: experiment_name
+    model_name: jet_tagger
+    num_trials: 1
+    sampler:
+      type: RandomSampler
+    hyperparameter_search:
+      numerical: {}
+      categorical: {}

--- a/src/pquant/configs/config_mdmm_paca.yaml
+++ b/src/pquant/configs/config_mdmm_paca.yaml
@@ -1,0 +1,71 @@
+# file: /src/pquant/configs/config_mdmm_paca.yaml
+# Pattern-based pruning (PACA). Forces EqualityConstraint with target 0.
+
+pruning_parameters:
+  pruning_method: mdmm
+  enable_pruning: true
+  disable_pruning_for_layers: []
+  constraint_type: "Equality"  # Forced internally; listed for clarity.
+  target_value: 0.0
+  metric_type: "PACAPatternSparsity"
+  target_sparsity: 0.9
+  rf: 1
+  epsilon: 1.0e-03
+  scale: 1.0
+  damping: 1.0
+  use_grad: false
+  constraint_lr: 1.0e-3
+  # PACAPatternMetric-specific
+  num_patterns_to_keep: 16
+  beta: 0.85
+  distance_metric: "cosine"   # "hamming", "valued_hamming", or "cosine"
+
+quantization_parameters:
+  enable_quantization: true
+  default_weight_keep_negatives: 1.
+  default_weight_integer_bits: 0.
+  default_weight_fractional_bits: 7.
+  default_data_keep_negatives: 0.
+  default_data_integer_bits: 0.
+  default_data_fractional_bits: 7.
+  granularity: "per_tensor"
+  quantize_input: true
+  quantize_output: false
+  hgq_beta: 1e-5
+  hgq_gamma: 0.0003
+  hgq_heterogeneous: True
+  layer_specific: {}
+  use_high_granularity_quantization: false
+  use_real_tanh: false
+  use_relu_multiplier: false
+  use_symmetric_quantization: false
+  overflow_mode_parameters: SAT
+  overflow_mode_data: SAT
+  round_mode: RND
+training_parameters:
+  epochs: 200
+  fine_tuning_epochs: 30
+  pretraining_epochs: 0
+  pruning_first: true
+  rewind: never
+  rounds: 1
+  save_weights_epoch: -1
+fitcompress_parameters:
+  enable_fitcompress : false
+  optimize_quantization : true
+  quantization_schedule : [7.,4.,3.,2]
+  pruning_schedule : {start : 0, end : -3, steps : 40}
+  compression_goal : 0.10
+  optimize_pruning : false
+  greedy_astar : true
+  approximate : true
+  f_lambda : 1
+hpo_parameters:
+    experiment_name: experiment_name
+    model_name: jet_tagger
+    num_trials: 1
+    sampler:
+      type: RandomSampler
+    hyperparameter_search:
+      numerical: {}
+      categorical: {}

--- a/src/pquant/core/constants.py
+++ b/src/pquant/core/constants.py
@@ -16,6 +16,8 @@ from pquant.pruning_methods.constraint_functions import (
     LessThanOrEqualConstraint,
 )
 from pquant.pruning_methods.metric_functions import (
+    FPGAAwareSparsityMetric,
+    PACAPatternMetric,
     StructuredSparsityMetric,
     UnstructuredSparsityMetric,
 )
@@ -58,6 +60,8 @@ N_JOBS = 1
 METRIC_REGISTRY = {
     "UnstructuredSparsity": UnstructuredSparsityMetric,
     "StructuredSparsity": StructuredSparsityMetric,
+    "FPGAAwareSparsity": FPGAAwareSparsityMetric,
+    "PACAPatternSparsity": PACAPatternMetric,
 }
 
 CONSTRAINT_REGISTRY = {

--- a/src/pquant/data_models/pruning_model.py
+++ b/src/pquant/data_models/pruning_model.py
@@ -67,6 +67,8 @@ class ActivationPruningModel(BasePruningModel):
 class MetricType(str, Enum):
     UNSTRUCTURED = "UnstructuredSparsity"
     STRUCTURED = "StructuredSparsity"
+    FPGA_AWARE = "FPGAAwareSparsity"
+    PACA_PATTERN = "PACAPatternSparsity"
 
 
 class ConstraintType(str, Enum):
@@ -89,3 +91,11 @@ class MDMMPruningModel(BasePruningModel):
     l0_mode: Literal["coarse", "smooth"] = Field(default="coarse")
     scale_mode: Literal["mean", "sum"] = Field(default="mean")
     constraint_lr: float = Field(default=1.0e-3)
+    # FPGAAwareSparsityMetric (only used when metric_type == "FPGAAwareSparsity")
+    precision: Optional[int] = Field(default=None)
+    target_resource: Optional[Literal["DSP", "BRAM"]] = Field(default=None)
+    bram_width: Optional[int] = Field(default=None)
+    # PACAPatternMetric (only used when metric_type == "PACAPatternSparsity")
+    num_patterns_to_keep: Optional[int] = Field(default=None)
+    beta: Optional[float] = Field(default=None)
+    distance_metric: Optional[Literal["hamming", "valued_hamming", "cosine"]] = Field(default=None)

--- a/src/pquant/pruning_methods/mdmm.py
+++ b/src/pquant/pruning_methods/mdmm.py
@@ -9,6 +9,7 @@ import keras
 from keras import ops
 
 from pquant.core.constants import CONSTRAINT_REGISTRY, METRIC_REGISTRY
+from pquant.pruning_methods.metric_functions import PACAPatternMetric
 
 # -------------------------------------------------------------------
 #                   MDMM Layer
@@ -44,6 +45,14 @@ class MDMM(keras.layers.Layer):
             "l0_mode": l0_mode,
             "scale_mode": scale_mode,
             "rf": pruning_parameters.rf,
+            # FPGAAwareSparsityMetric
+            "precision": pruning_parameters.precision,
+            "target_resource": pruning_parameters.target_resource,
+            "bram_width": pruning_parameters.bram_width,
+            # PACAPatternMetric
+            "num_patterns_to_keep": pruning_parameters.num_patterns_to_keep,
+            "beta": pruning_parameters.beta,
+            "distance_metric": pruning_parameters.distance_metric,
         }
 
         metric_cls = METRIC_REGISTRY.get(metric_type)
@@ -53,6 +62,11 @@ class MDMM(keras.layers.Layer):
             metric_fn = metric_cls(**metric_kwargs)
         else:
             raise ValueError(f"Unknown metric_type: {metric_type}")
+
+        # PACA always pairs with EqualityConstraint at target 0 (preserves original design).
+        if metric_type == "PACAPatternSparsity":
+            constraint_type = "Equality"
+            target_value = 0.0
 
         common_args = {
             "metric_fn": metric_fn,
@@ -89,7 +103,14 @@ class MDMM(keras.layers.Layer):
 
     def call(self, weight):
         epsilon = self.config.pruning_parameters.epsilon
-        hard_mask = ops.cast(ops.abs(weight) > epsilon, weight.dtype)
+        # PACA needs a projection mask in finetuning. By then, dominant_patterns are
+        # guaranteed populated from prior active-phase constraint calls. In other phases
+        # use the generic abs-threshold mask.
+        is_paca = isinstance(self.constraint_layer.metric_fn, PACAPatternMetric)
+        if is_paca and self._is_finetuning:
+            hard_mask = self.constraint_layer.metric_fn.get_projection_mask(weight)
+        else:
+            hard_mask = ops.cast(ops.abs(weight) > epsilon, weight.dtype)
         not_active = ops.logical_or(self.is_pretraining, self.is_finetuning)
         self.mask.assign(ops.where(not_active, ops.convert_to_tensor(self.mask), hard_mask))
 
@@ -105,7 +126,8 @@ class MDMM(keras.layers.Layer):
         return ops.cast(ops.abs(weight) > epsilon, weight.dtype)
 
     def get_layer_sparsity(self, weight):
-        return ops.sum(self.get_hard_mask(weight)) / ops.size(weight)
+        mask = self.get_hard_mask(weight)
+        return ops.sum(mask) / ops.cast(ops.size(weight), mask.dtype)
 
     def calculate_additional_loss(self):
         # Loss is added via self.add_loss() in call() for model.fit.

--- a/src/pquant/pruning_methods/metric_functions.py
+++ b/src/pquant/pruning_methods/metric_functions.py
@@ -1,4 +1,7 @@
+import keras
 from keras import ops
+
+from pquant.pruning_methods.utils import patterns
 
 
 class UnstructuredSparsityMetric:
@@ -83,3 +86,145 @@ class StructuredSparsityMetric:
         num_groups = ops.cast(ops.size(group_norms), "float32")
 
         return ops.sum(ops.cast(zero_groups, "float32")) / num_groups
+
+
+class FPGAAwareSparsityMetric:
+    """Hardware-aware sparsity metric for FPGA targets.
+
+    Models how weights are packed into DSP blocks (groups of size `rf`) and
+    further into BRAM blocks (groups of `c` DSP blocks, where `c` derives from
+    `bram_width` and `precision`). Returns the fraction of zero-valued groups
+    at the chosen target_resource level.
+    """
+
+    def __init__(self, rf=1, precision=16, target_resource='DSP',
+                 bram_width=36, epsilon=1e-3):
+        assert target_resource in ['DSP', 'BRAM'], "target_resource must be 'DSP' or 'BRAM'."
+        assert rf >= 1, "rf must be >= 1"
+        assert precision >= 1, "precision must be >= 1"
+        assert bram_width >= 1, "bram_width must be >= 1"
+        self.rf = rf
+        self.precision = precision
+        self.target_resource = target_resource
+        self.bram_width = bram_width
+        self.epsilon = epsilon
+
+        self.c = self._calculate_c()
+        assert self.c >= 1, (
+            f"Computed c={self.c} from precision={precision}, bram_width={bram_width}. "
+            "BRAM packing requires precision <= 2*bram_width."
+        )
+
+    def _calculate_c(self):
+        """Calculates 'C', the number of consecutive DSP groups packed into a single BRAM block."""
+        if self.bram_width % self.precision == 0:
+            return self.bram_width // self.precision
+        else:
+            return (2 * self.bram_width) // self.precision
+
+    def _prepare_weights(self, weight):
+        """Reshapes and pads the weight tensor to align with the Reuse Factor (RF)."""
+        original_shape = weight.shape
+        # 1D (e.g. bias) -> single-row matrix; 2D -> as-is; >2D (e.g. Conv2D) -> flatten trailing dims.
+        if len(original_shape) == 1:
+            weight_reshaped = ops.reshape(weight, (1, -1))
+        elif len(original_shape) > 2:
+            weight_reshaped = ops.reshape(weight, (original_shape[0], -1))
+        else:
+            weight_reshaped = weight
+
+        num_weights = ops.shape(weight_reshaped)[1]
+        padding_needed = (self.rf - num_weights % self.rf) % self.rf
+        weight_padded = ops.pad(weight_reshaped, [[0, 0], [0, padding_needed]])
+
+        return weight_padded
+
+    def __call__(self, weight):
+        prepared_weights = self._prepare_weights(weight)
+        dsp_groups = ops.reshape(prepared_weights, (prepared_weights.shape[0], -1, self.rf))
+
+        if self.target_resource == 'DSP':
+            return self._calculate_dsp_sparsity(dsp_groups)
+        elif self.target_resource == 'BRAM':
+            return self._calculate_bram_sparsity(dsp_groups)
+
+    def _calculate_dsp_sparsity(self, dsp_groups):
+        """A DSP block is "pruned" if the L2-norm of its weight group is below epsilon."""
+        group_norms = ops.sqrt(ops.sum(ops.square(dsp_groups), axis=-1))
+        zero_groups = ops.less_equal(group_norms, self.epsilon)
+        num_groups = ops.cast(ops.size(group_norms), dsp_groups.dtype)
+        # TODO Align with some target
+        return ops.sum(ops.cast(zero_groups, dsp_groups.dtype)) / num_groups
+
+    def _calculate_bram_sparsity(self, dsp_groups):
+        """A BRAM block is "pruned" if the L2-norm of all weights stored in it is below epsilon."""
+        num_dsp_groups = ops.shape(dsp_groups)[1]
+        bram_padding = (self.c - num_dsp_groups % self.c) % self.c
+        dsp_groups_padded = ops.pad(dsp_groups, [[0, 0], [0, bram_padding], [0, 0]])
+        bram_groups = ops.reshape(dsp_groups_padded, (dsp_groups.shape[0], -1, self.c, self.rf))
+
+        bram_group_norms = ops.sqrt(ops.sum(ops.square(bram_groups), axis=(-1, -2)))
+        zero_bram_groups = ops.less_equal(bram_group_norms, self.epsilon)
+        num_bram_groups = ops.cast(ops.size(bram_group_norms), dsp_groups.dtype)
+        return ops.sum(ops.cast(zero_bram_groups, dsp_groups.dtype)) / num_bram_groups
+
+
+class PACAPatternMetric:
+    """Pattern-based pruning metric (PACA).
+
+    Selects a small set of dominant binary patterns over kernel layouts on the
+    first call (cached for the metric instance lifetime). Returns the mean
+    distance of every kernel to its closest dominant pattern. Operates on 4D
+    Conv2D weights only; returns 0 for non-4D inputs.
+    """
+
+    def __init__(self, num_patterns_to_keep=16, beta=0.75,
+                 epsilon=1e-5, distance_metric='valued_hamming'):
+        assert num_patterns_to_keep > 0, "num_patterns_to_keep must be > 0"
+        assert 0.0 <= beta <= 1.0, "beta must be in [0, 1]"
+        assert distance_metric in ('hamming', 'valued_hamming', 'cosine'), (
+            f"distance_metric must be one of hamming/valued_hamming/cosine, got {distance_metric!r}"
+        )
+        self.alpha = num_patterns_to_keep
+        self.beta = beta
+        self.distance_metric = distance_metric
+        self.epsilon = epsilon
+        self.dominant_patterns = None
+        self.projection_mask = None
+        self.src = "OIHW"
+
+    def __call__(self, weight):
+        if len(weight.shape) != 4:
+            return ops.convert_to_tensor(0.0, dtype=weight.dtype)
+
+        if self.dominant_patterns is None:
+            _, all_patterns, _ = patterns._get_kernels_and_patterns(weight, self.src, self.epsilon)
+            unique_patterns, counts = patterns._get_unique_patterns_with_counts(all_patterns)
+            self.dominant_patterns = patterns._select_dominant_patterns(
+                all_patterns, unique_patterns, counts,
+                alpha=self.alpha, beta=self.beta, dtype=weight.dtype,
+            )
+
+        if self.dominant_patterns is None or self.dominant_patterns.shape[0] == 0:
+            return ops.convert_to_tensor(0.0, dtype=weight.dtype)
+
+        w_kernels, distances = patterns._pattern_distances(
+            weight, self.dominant_patterns,
+            self.src, self.epsilon, self.distance_metric,
+        )
+        min_distances = ops.min(distances, axis=1)
+        return ops.mean(min_distances)
+
+    def get_projection_mask(self, weight):
+        # If patterns weren't selected (e.g. metric was never invoked, or weight is non-4D),
+        # return an identity mask so MDMM.call's `weight * mask` is a no-op.
+        if self.dominant_patterns is None or self.dominant_patterns.shape[0] == 0:
+            return ops.ones_like(weight)
+        if self.projection_mask is None:
+            self.projection_mask = patterns._get_projection_mask(
+                weight, self.dominant_patterns, self.src, self.epsilon, self.distance_metric,
+            )
+        return self.projection_mask
+
+    def get_dominant_patterns(self):
+        return self.dominant_patterns

--- a/src/pquant/pruning_methods/utils/patterns.py
+++ b/src/pquant/pruning_methods/utils/patterns.py
@@ -1,0 +1,155 @@
+from functools import lru_cache
+import numpy as np
+import keras
+from keras import ops
+
+_AX = {"H": 0,   # kernel height  (kH)
+       "W": 1,   # kernel width   (kW)
+       "I": 2,   # input  channels (C_in)
+       "O": 3}   # output channels (C_out)
+
+def _layout_to_axes(layout: str):
+    if len(layout) != 4 or set(layout) != set("HWIO"):
+        raise ValueError("layout must be a permutation of 'HWIO'")
+    return tuple(_AX[ch] for ch in layout)
+
+@lru_cache(maxsize=None)
+def _perm(src: str, dst: str):
+    """
+    Constant-time (cached) permutation tuple that reorders *src*→*dst*.
+    """
+    s = _layout_to_axes(src)
+    d = _layout_to_axes(dst)
+    return tuple(s.index(ax) for ax in d)
+
+
+def convert_conv_layout(w, src: str, dst: str = "HWIO"):
+    if src == dst:
+        return w
+    perm = _perm(src, dst)                     # Python‑level, cached
+    if perm == (0, 1, 2, 3):                   # identity permutation
+        return w
+    return ops.transpose(w, perm)
+
+
+def _get_kernels_and_patterns(w, src="OIHW", epsilon=1e-5):
+    # src:
+    #   PyTorch: (out, in, kH, kW): OIHW
+    #   Keras  : (kH, kW, in, out): HWIO
+    w_permuted = convert_conv_layout(w, src="OIHW", dst="OIHW")
+    C_out, C_in, kH, kW = ops.shape(w_permuted)
+    kernels = ops.reshape(w_permuted, (C_out * C_in, -1))
+    all_patterns = ops.cast(ops.greater(ops.abs(kernels), epsilon), dtype="uint8")
+
+    return kernels, all_patterns, (C_out, C_in, kH, kW)
+
+def _get_unique_patterns_with_counts(all_patterns):
+    """Returns the unique patterns and their counts."""
+    np_patterns = ops.convert_to_numpy(all_patterns)
+    # This is currently in nummpy implementation
+    uniq_np, counts_np = np.unique(np_patterns, axis=0, return_counts=True)
+
+    unique_patterns = ops.convert_to_tensor(uniq_np, dtype=all_patterns.dtype)
+    counts          = ops.convert_to_tensor(counts_np.astype("int32"), dtype="int32")
+    return unique_patterns, counts
+
+def _select_dominant_patterns(all_patterns, unique_patterns, counts, alpha, beta, dtype=None):
+    """Selects the most frequent patterns based on alpha and beta."""
+    if not dtype:
+        raise ValueError("dtype must be provided")
+    if ops.shape(unique_patterns)[0] == 0:
+        return unique_patterns
+
+    total = ops.cast(ops.shape(all_patterns)[0], dtype)
+    pdf   = ops.cast(counts, dtype) / total
+
+    order   = ops.argsort(-pdf)
+    pdf_s   = ops.take(pdf, order)
+    pat_s   = ops.take(unique_patterns, order, axis=0)
+
+    cdf     = ops.cumsum(pdf_s)
+    mask    = cdf >= beta
+    has_hit = ops.any(mask)
+
+    idx      = ops.argmax(mask)
+    n_beta   = ops.cast(idx + 1, counts.dtype)
+    n_total  = ops.cast(ops.shape(cdf)[0], counts.dtype)
+
+    keep_beta = ops.where(has_hit, n_beta, n_total)
+    keep      = ops.minimum(keep_beta, ops.cast(alpha, counts.dtype))
+
+    return pat_s[:keep]
+
+
+def count_dominant_patterns(dominant_patterns, unique_patterns, counts):
+    """
+    Shapes:
+      dominant_patterns: [M, K]
+      unique_patterns:   [U, K]
+      counts:            [U]
+    """
+    dp_exp = ops.expand_dims(dominant_patterns, axis=1)  # [M, 1, K]
+    up_exp = ops.expand_dims(unique_patterns, axis=0)    # [1, U, K]
+    matches = ops.all(ops.equal(dp_exp, up_exp), axis=-1)  # [M, U]
+
+    idx = ops.argmax(matches, axis=1)  # [M]
+    dom_counts = ops.take(counts, idx, axis=0)  # [M]
+    return dom_counts
+
+
+def calc_pattern_distances(Tk, P, k, distance_metric='cosine'):
+    """
+    Compute distances between a set of target kernels Tk and a set of patterns P,
+    using the specified distance metric.
+    """
+    # Cast uint8 patterns/kernel-binarization to the kernel float dtype so
+    # arithmetic with the float kernels works under TF's strict-dtype rules.
+    Tk = ops.cast(Tk, k.dtype)
+    P = ops.cast(P, k.dtype)
+    Tk_exp = ops.expand_dims(Tk, 1)
+    k_exp = ops.expand_dims(k, 1)
+    P_exp = ops.expand_dims(P, 0)
+
+
+    if distance_metric == 'hamming':
+        distances = ops.sum(ops.abs(Tk_exp - P_exp), axis=-1)
+    elif distance_metric == 'valued_hamming':
+        abs_diff = ops.abs(Tk_exp - P_exp)
+        distances = ops.sum(abs_diff * ops.abs(k_exp), axis=-1)
+    elif distance_metric == 'cosine':
+        projected_kernels = k_exp * P_exp
+        k_dot_projected = ops.sum(k_exp * projected_kernels, axis=-1)
+        norm_k = ops.norm(k_exp, axis=-1)
+        norm_projected = ops.norm(projected_kernels, axis=-1)
+        cosine_similarity = k_dot_projected / (norm_k * norm_projected + keras.backend.epsilon())
+        distances = 1.0 - cosine_similarity
+    else:
+        raise ValueError(f"Unsupported distance metric: {distance_metric}")
+
+    return distances
+
+
+def _pattern_distances(w, dominant_patterns, src="OIHW", epsilon=1e-5, distance_metric='cosine'):
+    """Calculates the distance of all kernels to the set of dominant patterns."""
+    if dominant_patterns is None:
+        raise ValueError("Dominant patterns have not been selected yet.")
+
+    w_kernels, w_patterns, _ = _get_kernels_and_patterns(w, src, epsilon)
+    distances = calc_pattern_distances(w_patterns, dominant_patterns,
+                                       w_kernels, distance_metric)
+
+    return w_kernels, distances
+
+def _get_projection_mask(weight, dominant_patterns, src="OIHW", epsilon=1e-5, distance_metric='cosine'):
+    if len(ops.shape(weight)) != 4:
+        return ops.ones_like(weight)
+    _, _, (C_out, C_in, kH, kW) = _get_kernels_and_patterns(weight, src, epsilon=0.0)
+    _, distances = _pattern_distances(weight, dominant_patterns,
+                                      src,
+                                      epsilon,
+                                      distance_metric)  # Shape: (C_out*C_in, num_dominant)
+    closest_pattern_indices = ops.argmin(distances, axis=1)  # Shape: (C_out*C_in,)
+    projection_mask_flat = ops.take(dominant_patterns, closest_pattern_indices, axis=0)
+    projection_mask = ops.reshape(projection_mask_flat, (C_out, C_in, kH, kW))
+    # Cast back to the weight dtype so downstream `weight * mask` works under TF strict dtypes.
+    return ops.cast(projection_mask, weight.dtype)

--- a/tests/test_mdmm.py
+++ b/tests/test_mdmm.py
@@ -1,0 +1,437 @@
+import math
+
+import numpy as np
+import pytest
+from keras import ops
+
+from pquant.pruning_methods.constraint_functions import (
+    EqualityConstraint,
+    GreaterThanOrEqualConstraint,
+    LessThanOrEqualConstraint,
+)
+from pquant.pruning_methods.mdmm import MDMM
+from pquant.pruning_methods.metric_functions import (
+    # StructuredSparsityMetric,
+    UnstructuredSparsityMetric,
+    # TODO: add PACA and FPGA metric functions after integrating them
+)
+
+IN_FEATURES = 8
+OUT_FEATURES = 16
+
+
+@pytest.fixture
+def config():
+    return {
+        "pruning_parameters": {
+            "pruning_method": "mdmm",
+            "disable_pruning_for_layers": [],
+            "enable_pruning": True,
+            "constraint_type": "Equality",
+            "target_value": 0.0,
+            "metric_type": "UnstructuredSparsity",
+            "target_sparsity": 0.5,
+            "rf": 1,
+            "epsilon": 1e-3,
+            "scale": 1.0,
+            "damping": 1.0,
+            "use_grad": False,
+            "l0_mode": "coarse",
+            "scale_mode": "mean",
+            "constraint_lr": 0.0,
+        }
+    }
+
+
+# Metric functions in isolation
+
+
+def test_unstructured_sparsity_coarse_mean_satisfied():
+    """weight=[0,0,1,2], target=0.5 -> L0=0.5, factor=0, metric=0."""
+    metric = UnstructuredSparsityMetric(l0_mode="coarse", scale_mode="mean", epsilon=1e-3, target_sparsity=0.5)
+    weight = ops.convert_to_tensor([0.0, 0.0, 1.0, 2.0], dtype="float32")
+    result = metric(weight)
+    assert ops.abs(result) < 1e-6
+
+
+def test_unstructured_sparsity_coarse_mean_unsatisfied():
+    """weight=[0,0,0,2], target=0.5 -> L0=0.75, factor=-0.3125, metric=-0.15625."""
+    metric = UnstructuredSparsityMetric(l0_mode="coarse", scale_mode="mean", epsilon=1e-3, target_sparsity=0.5)
+    weight = ops.convert_to_tensor([0.0, 0.0, 0.0, 2.0], dtype="float32")
+    result = metric(weight)
+    # L0 = mean([T,T,T,F]) = 0.75
+    # L1 = 2.0
+    # factor = 0.25 - 0.5625 = -0.3125
+    # fn = -0.3125 * 2.0 / 4 = -0.15625
+    expected = -0.15625
+    assert ops.abs(result - expected) < 1e-5
+
+
+def test_unstructured_sparsity_coarse_sum():
+    """Same as unsatisfied but scale_mode='sum' -> no division by num_weights."""
+    metric = UnstructuredSparsityMetric(l0_mode="coarse", scale_mode="sum", epsilon=1e-3, target_sparsity=0.5)
+    weight = ops.convert_to_tensor([0.0, 0.0, 0.0, 2.0], dtype="float32")
+    result = metric(weight)
+    # fn = -0.3125 * 2.0 = -0.625
+    expected = -0.625
+    assert ops.abs(result - expected) < 1e-5
+
+
+def test_unstructured_sparsity_smooth_at_zeros():
+    """weight=[0,0,1,2], target=0.5 -> smooth L0 ~ 0.5, metric ~ 0."""
+    metric = UnstructuredSparsityMetric(l0_mode="smooth", scale_mode="mean", epsilon=1e-3, target_sparsity=0.5)
+    weight = ops.convert_to_tensor([0.0, 0.0, 1.0, 2.0], dtype="float32")
+    result = metric(weight)
+    # exp(-100*0)=1, exp(-100*1)~0, exp(-100*4)~0 -> smooth_L0 ~ 0.5
+    assert ops.abs(result) < 1e-4
+
+
+def test_unstructured_sparsity_smooth_nonzero():
+    """weight=[0.1,0.1,1,2], target=0.5 -> smooth L0 ~ 0.184, metric ~ 0.173."""
+    metric = UnstructuredSparsityMetric(l0_mode="smooth", scale_mode="mean", epsilon=1e-3, target_sparsity=0.5)
+    weight = ops.convert_to_tensor([0.1, 0.1, 1.0, 2.0], dtype="float32")
+    result = metric(weight)
+    # exp(-100*0.01)=exp(-1)=0.3679, exp(-100*1)~0, exp(-100*4)~0
+    # smooth_L0 = mean([0.3679, 0.3679, ~0, ~0]) = 0.18395
+    # factor = 0.25 - 0.18395^2 = 0.25 - 0.03384 = 0.21616
+    # L1 = 0.1+0.1+1.0+2.0 = 3.2
+    # fn = 0.21616 * 3.2 / 4 = 0.17293
+    smooth_l0 = (2 * math.exp(-1.0)) / 4.0
+    factor = 0.5**2 - smooth_l0**2
+    l1 = 3.2
+    expected = factor * l1 / 4.0
+    assert ops.abs(result - expected) < 1e-4
+
+
+# Constraint functions in isolation
+
+
+class ConstantMetric:
+    """A simple metric that always returns a fixed value, for isolating constraint logic."""
+
+    def __init__(self, value):
+        self.value = value
+
+    def __call__(self, weight):
+        return ops.convert_to_tensor(self.value, dtype="float32")
+
+
+def test_equality_constraint():
+    """metric=0.3, target=0.0 -> inf=0.3, penalty=1*(1*0.3 + 1*0.09/2) = 0.345."""
+    metric_fn = ConstantMetric(0.3)
+    constraint = EqualityConstraint(metric_fn=metric_fn, target_value=0.0, scale=1.0, damping=1.0, use_grad=False, lr=0.0)
+    dummy = ops.zeros((2, 2))
+    constraint.build(dummy.shape)
+    result = constraint(dummy)
+    # inf = |0.3 - 0.0| = 0.3
+    # lmbda_step = 0 (lr=0), ascent_lmbda = 1.0
+    # l_term = 1.0 * 0.3, damp_term = 1.0 * 0.09 / 2 = 0.045
+    # penalty = 1.0 * (0.3 + 0.045) = 0.345
+    expected = 0.345
+    assert ops.abs(result - expected) < 1e-5
+
+
+def test_leq_constraint_satisfied():
+    """metric=0.3, target=0.5 -> inf=max(-0.2, 0)=0, penalty=0."""
+    metric_fn = ConstantMetric(0.3)
+    constraint = LessThanOrEqualConstraint(metric_fn=metric_fn, target_value=0.5, scale=1.0, damping=1.0, use_grad=False, lr=0.0)
+    dummy = ops.zeros((2, 2))
+    constraint.build(dummy.shape)
+    result = constraint(dummy)
+    assert ops.abs(result) < 1e-6
+
+
+def test_leq_constraint_violated():
+    """metric=0.7, target=0.5 -> inf=0.2, penalty=0.22."""
+    metric_fn = ConstantMetric(0.7)
+    constraint = LessThanOrEqualConstraint(metric_fn=metric_fn, target_value=0.5, scale=1.0, damping=1.0, use_grad=False, lr=0.0)
+    dummy = ops.zeros((2, 2))
+    constraint.build(dummy.shape)
+    result = constraint(dummy)
+    # inf = max(0.7 - 0.5, 0) = 0.2
+    # l_term = 1.0 * 0.2, damp_term = 1.0 * 0.04 / 2 = 0.02
+    # penalty = 1.0 * (0.2 + 0.02) = 0.22
+    expected = 0.22
+    assert ops.abs(result - expected) < 1e-5
+
+
+def test_geq_constraint_satisfied():
+    """metric=0.7, target=0.5 -> inf=max(-0.2, 0)=0, penalty=0."""
+    metric_fn = ConstantMetric(0.7)
+    constraint = GreaterThanOrEqualConstraint(metric_fn=metric_fn, target_value=0.5, scale=1.0, damping=1.0, use_grad=False, lr=0.0)
+    dummy = ops.zeros((2, 2))
+    constraint.build(dummy.shape)
+    result = constraint(dummy)
+    assert ops.abs(result) < 1e-6
+
+
+def test_geq_constraint_violated():
+    """metric=0.3, target=0.5 -> inf=0.2, penalty=0.22."""
+    metric_fn = ConstantMetric(0.3)
+    constraint = GreaterThanOrEqualConstraint(metric_fn=metric_fn, target_value=0.5, scale=1.0, damping=1.0, use_grad=False, lr=0.0)
+    dummy = ops.zeros((2, 2))
+    constraint.build(dummy.shape)
+    result = constraint(dummy)
+    expected = 0.22
+    assert ops.abs(result - expected) < 1e-5
+
+
+def test_constraint_turn_off():
+    """After turn_off(), penalty should be 0."""
+    metric_fn = ConstantMetric(0.5)
+    constraint = EqualityConstraint(metric_fn=metric_fn, target_value=0.0, scale=10.0, damping=5.0, use_grad=False, lr=0.0)
+    dummy = ops.zeros((2, 2))
+    constraint.build(dummy.shape)
+    constraint.turn_off()
+    result = constraint(dummy)
+    assert ops.abs(result) < 1e-6
+
+
+def test_constraint_lambda_update_no_grad():
+    """With lr>0, lambda should update between calls, changing the penalty."""
+    metric_fn = ConstantMetric(0.3)
+    constraint = EqualityConstraint(metric_fn=metric_fn, target_value=0.0, scale=2.0, damping=1.0, use_grad=False, lr=0.1)
+    dummy = ops.zeros((2, 2))
+    constraint.build(dummy.shape)
+
+    # First call (training=True): prev_infs=0, so lmbda_step=0, ascent_lmbda=1.0
+    result1 = constraint(dummy, training=True)
+    # After first call: prev_infs = 0.3, lmbda += 0 (still 1.0)
+
+    # Second call (training=True): lmbda_step = 0.1 * 2.0 * 0.3 = 0.06
+    # ascent_lmbda = 1.0 + 0.06 = 1.06
+    result2 = constraint(dummy, training=True)
+
+    # Penalty should differ between calls due to lambda update
+    assert not ops.isclose(result1, result2)
+
+
+# Mask correctness
+
+
+def test_hard_mask_threshold(config):
+    """Verify mask at epsilon boundary: |w| > epsilon -> 1, else 0."""
+    weight = ops.convert_to_tensor(
+        [[1e-4, 1e-3, 1e-2, 0.1],
+         [-1e-4, -1e-3, -1e-2, -0.1]],
+        dtype="float32",
+    )
+    expected_mask = ops.convert_to_tensor(
+        [[0.0, 0.0, 1.0, 1.0],
+         [0.0, 0.0, 1.0, 1.0]],
+        dtype="float32",
+    )
+    mdmm = MDMM(config, "linear")
+    mdmm.build(weight.shape)
+    mdmm.post_pre_train_function()  # transition to active phase
+    mdmm(weight)
+    assert ops.all(ops.equal(ops.convert_to_tensor(mdmm.mask), expected_mask))
+
+
+
+@pytest.mark.xfail(raises=TypeError, strict=False, reason="Known bug: get_layer_sparsity has float32/int32 dtype mismatch on TF backend")
+def test_get_layer_sparsity(config):
+    """Half zero, half nonzero -> sparsity = 0.5."""
+    weight = ops.convert_to_tensor(
+        [[1e-4, 1e-3, 1e-2, 0.1],
+         [-1e-4, -1e-3, -1e-2, -0.1]],
+        dtype="float32",
+    )
+    mdmm = MDMM(config, "linear")
+    mdmm.build(weight.shape)
+    # 4 out of 8 above epsilon -> keep ratio = 0.5
+    sparsity = mdmm.get_layer_sparsity(weight)
+    assert ops.abs(sparsity - 0.5) < 1e-5
+
+
+# MDMM training phases
+
+
+def _make_mixed_weight_linear():
+    """Weight with ~75% zeros (below epsilon) and ~25% nonzero.
+    With target_sparsity=0.5, this ensures L0 != target -> nonzero penalty."""
+    vals = np.zeros(OUT_FEATURES * IN_FEATURES, dtype=np.float32)
+    quarter = len(vals) // 4
+    vals[-quarter:] = np.linspace(0.01, 1.0, quarter)
+    return ops.convert_to_tensor(vals.reshape(OUT_FEATURES, IN_FEATURES))
+
+
+
+def test_pretraining_phase_linear(config):
+    """Pretraining: mask stays ones, no penalty, output unchanged."""
+    weight = _make_mixed_weight_linear()
+    mdmm = MDMM(config, "linear")
+    mdmm.build(weight.shape)
+    # Still in pretraining phase (default)
+    result = mdmm(weight)
+
+    assert ops.all(ops.equal(result, weight))
+    assert ops.all(ops.equal(ops.convert_to_tensor(mdmm.mask), ops.ones(weight.shape)))
+    assert mdmm.losses[-1] < 1e-8
+
+
+def test_active_phase_linear(config):
+    """Active: mask updated, penalty nonzero, output unchanged."""
+    weight = _make_mixed_weight_linear()
+    mdmm = MDMM(config, "linear")
+    mdmm.build(weight.shape)
+    mdmm.post_pre_train_function()  # -> active
+
+    result = mdmm(weight)
+    expected_mask = ops.cast(ops.abs(weight) > config["pruning_parameters"]["epsilon"], weight.dtype)
+
+    assert ops.all(ops.equal(result, weight))
+    assert ops.all(ops.equal(ops.convert_to_tensor(mdmm.mask), expected_mask))
+    assert mdmm.losses[-1] > 1e-8
+
+
+def test_finetuning_phase_linear(config):
+    """Finetuning: mask frozen, no penalty, output = weight * hard_mask."""
+    weight = _make_mixed_weight_linear()
+    epsilon = config["pruning_parameters"]["epsilon"]
+    mdmm = MDMM(config, "linear")
+    mdmm.build(weight.shape)
+    mdmm.post_pre_train_function()  # -> active
+    mdmm(weight)  # update mask
+    mdmm.pre_finetune_function()  # -> finetuning
+
+    result = mdmm(weight)
+    hard_mask = ops.cast(ops.abs(weight) > epsilon, weight.dtype)
+    expected_output = weight * hard_mask
+
+    assert ops.all(ops.equal(result, expected_output))
+    assert mdmm.losses[-1] < 1e-8
+
+
+
+# Penalty numerical verification (full chain)
+
+
+def test_penalty_satisfied(config):
+    """weight=[0,0,1,2] at target=0.5 -> metric=0 -> penalty=0."""
+    config["pruning_parameters"]["target_sparsity"] = 0.5
+    weight = ops.convert_to_tensor([[0.0, 0.0], [1.0, 2.0]], dtype="float32")
+    mdmm = MDMM(config, "linear")
+    mdmm.build(weight.shape)
+    mdmm.post_pre_train_function()
+    mdmm(weight)
+    assert mdmm.losses[-1] < 1e-6
+
+
+def test_penalty_unsatisfied(config):
+    """weight=[0,0,0,2] at target=0.5 -> known penalty value."""
+    config["pruning_parameters"]["target_sparsity"] = 0.5
+    weight = ops.convert_to_tensor([[0.0, 0.0], [0.0, 2.0]], dtype="float32")
+    mdmm = MDMM(config, "linear")
+    mdmm.build(weight.shape)
+    mdmm.post_pre_train_function()
+    mdmm(weight)
+
+    # metric = -0.15625 (from Group A)
+    # EqualityConstraint: inf = |-0.15625| = 0.15625
+    # penalty_per_element = 1.0 * (1.0 * 0.15625 + 1.0 * 0.15625^2 / 2) = 0.16846
+    # MDMM does ops.sum(constraint(weight)) -> single scalar, so penalty = 0.16846
+    expected = 0.15625 + 0.15625**2 / 2.0
+    assert ops.abs(mdmm.losses[-1] - expected) < 1e-4
+
+
+def test_penalty_with_scale_and_damping(config):
+    """Same weight but scale=10, damping=2 -> larger penalty."""
+    config["pruning_parameters"]["target_sparsity"] = 0.5
+    config["pruning_parameters"]["scale"] = 10.0
+    config["pruning_parameters"]["damping"] = 2.0
+    weight = ops.convert_to_tensor([[0.0, 0.0], [0.0, 2.0]], dtype="float32")
+    mdmm = MDMM(config, "linear")
+    mdmm.build(weight.shape)
+    mdmm.post_pre_train_function()
+    mdmm(weight)
+
+    # inf = 0.15625
+    # l_term = 1.0 * 0.15625 (lmbda=1.0)
+    # damp_term = 2.0 * 0.15625^2 / 2 = 0.02441
+    # penalty = 10.0 * (0.15625 + 0.02441) = 1.80664
+    inf_val = 0.15625
+    expected = 10.0 * (1.0 * inf_val + 2.0 * inf_val**2 / 2.0)
+    assert ops.abs(mdmm.losses[-1] - expected) < 1e-3
+
+
+# Constraint type variations (full chain)
+
+
+def test_leq_full_chain_satisfied(config):
+    """LEQ constraint with metric < 0 (satisfied) -> penalty ~ 0."""
+    config["pruning_parameters"]["constraint_type"] = "LessThanOrEqual"
+    config["pruning_parameters"]["target_sparsity"] = 0.5
+    # weight=[0,0,0,2]: metric = -0.15625. LEQ target_value=0 -> inf = max(-0.15625, 0) = 0
+    weight = ops.convert_to_tensor([[0.0, 0.0], [0.0, 2.0]], dtype="float32")
+    mdmm = MDMM(config, "linear")
+    mdmm.build(weight.shape)
+    mdmm.post_pre_train_function()
+    mdmm(weight)
+    assert mdmm.losses[-1] < 1e-6
+
+
+def test_geq_full_chain_violated(config):
+    """GEQ constraint with metric < 0 (violated) -> nonzero penalty."""
+    config["pruning_parameters"]["constraint_type"] = "GreaterThanOrEqual"
+    config["pruning_parameters"]["target_sparsity"] = 0.5
+    # metric = -0.15625, GEQ target=0 -> inf = max(0 - (-0.15625), 0) = 0.15625
+    weight = ops.convert_to_tensor([[0.0, 0.0], [0.0, 2.0]], dtype="float32")
+    mdmm = MDMM(config, "linear")
+    mdmm.build(weight.shape)
+    mdmm.post_pre_train_function()
+    mdmm(weight)
+    assert mdmm.losses[-1] > 1e-4
+
+
+# L0 mode variations
+
+
+
+def test_smooth_differs_from_coarse_in_soft_region(config):
+    """For w=0.05, smooth L0 differs from coarse -> different penalties."""
+    weight = ops.convert_to_tensor([[0.05, 0.05], [1.0, 2.0]], dtype="float32")
+
+    config["pruning_parameters"]["l0_mode"] = "coarse"
+    mdmm_coarse = MDMM(config, "linear")
+    mdmm_coarse.build(weight.shape)
+    mdmm_coarse.post_pre_train_function()
+    mdmm_coarse(weight)
+    loss_coarse = mdmm_coarse.losses[-1]
+
+    config["pruning_parameters"]["l0_mode"] = "smooth"
+    mdmm_smooth = MDMM(config, "linear")
+    mdmm_smooth.build(weight.shape)
+    mdmm_smooth.post_pre_train_function()
+    mdmm_smooth(weight)
+    loss_smooth = mdmm_smooth.losses[-1]
+
+    # Coarse: |0.05| > 1e-3 so L0=0 (no zeros). Smooth: exp(-100*0.0025)=exp(-0.25)~0.78
+    # These produce different L0 values -> different penalties
+    assert not ops.isclose(loss_coarse, loss_smooth)
+
+
+
+# Edge cases
+
+
+def test_all_zero_weights(config):
+    """All-zero weights -> L1=0, so metric=factor*0=0 -> penalty=0."""
+    weight = ops.zeros((4, 4))
+    mdmm = MDMM(config, "linear")
+    mdmm.build(weight.shape)
+    mdmm.post_pre_train_function()
+    mdmm(weight)
+    assert mdmm.losses[-1] < 1e-6
+
+
+def test_all_large_weights(config):
+    """No weights below epsilon -> L0=0 -> factor=target^2 > 0 -> nonzero penalty."""
+    weight = ops.ones((4, 4))
+    mdmm = MDMM(config, "linear")
+    mdmm.build(weight.shape)
+    mdmm.post_pre_train_function()
+    mdmm(weight)
+    assert mdmm.losses[-1] > 1e-4
+
+

--- a/tests/test_mdmm.py
+++ b/tests/test_mdmm.py
@@ -229,7 +229,6 @@ def test_hard_mask_threshold(config):
 
 
 
-@pytest.mark.xfail(raises=TypeError, strict=False, reason="Known bug: get_layer_sparsity has float32/int32 dtype mismatch on TF backend")
 def test_get_layer_sparsity(config):
     """Half zero, half nonzero -> sparsity = 0.5."""
     weight = ops.convert_to_tensor(

--- a/tests/test_mdmm_metrics.py
+++ b/tests/test_mdmm_metrics.py
@@ -1,0 +1,310 @@
+import math
+
+import numpy as np
+import pytest
+from keras import ops
+
+from pquant.pruning_methods.mdmm import MDMM
+from pquant.pruning_methods.metric_functions import (
+    FPGAAwareSparsityMetric,
+    PACAPatternMetric,
+)
+from pquant.pruning_methods.utils import patterns
+
+
+@pytest.fixture
+def base_config():
+    return {
+        "pruning_parameters": {
+            "pruning_method": "mdmm",
+            "disable_pruning_for_layers": [],
+            "enable_pruning": True,
+            "constraint_type": "Equality",
+            "target_value": 0.0,
+            "metric_type": "UnstructuredSparsity",
+            "target_sparsity": 0.5,
+            "rf": 1,
+            "epsilon": 1e-3,
+            "scale": 1.0,
+            "damping": 1.0,
+            "use_grad": False,
+            "l0_mode": "coarse",
+            "scale_mode": "mean",
+            "constraint_lr": 0.0,
+        }
+    }
+
+
+def _make_conv_weight(c_out=4, c_in=2, kh=3, kw=3, seed=42):
+    rng = np.random.default_rng(seed)
+    return ops.convert_to_tensor(rng.standard_normal((c_out, c_in, kh, kw)).astype(np.float32))
+
+
+# FPGAAwareSparsityMetric
+
+
+@pytest.mark.parametrize(
+    "target_resource,fill,expected",
+    [
+        ("DSP", 0.0, 1.0),   # all zero -> 100% pruned
+        ("DSP", 1.0, 0.0),   # all large -> 0% pruned
+        ("BRAM", 0.0, 1.0),
+        ("BRAM", 1.0, 0.0),
+    ],
+)
+def test_fpga_extreme_weights(target_resource, fill, expected):
+    metric = FPGAAwareSparsityMetric(
+        rf=2, precision=16, bram_width=36, target_resource=target_resource, epsilon=1e-3,
+    )
+    weight = ops.cast(ops.full((4, 16), fill), "float32")
+    result = metric(weight)
+    assert ops.abs(result - expected) < 1e-5
+
+
+def test_fpga_dsp_l2_grouping_math():
+    """[[1,1,0,0]] with rf=2 -> groups [1,1] (norm sqrt(2)) and [0,0] (norm 0). Result = 1/2."""
+    metric = FPGAAwareSparsityMetric(rf=2, target_resource="DSP", epsilon=1e-3)
+    weight = ops.convert_to_tensor([[1.0, 1.0, 0.0, 0.0]], dtype="float32")
+    result = metric(weight)
+    assert ops.abs(result - 0.5) < 1e-5
+
+
+@pytest.mark.parametrize(
+    "precision,bram_width,expected_c",
+    [
+        (16, 36, 4),  # 36 % 16 != 0 -> (2*36)//16 = 4
+        (18, 36, 2),  # 36 % 18 == 0 -> 36//18 = 2
+    ],
+)
+def test_fpga_calculate_c(precision, bram_width, expected_c):
+    metric = FPGAAwareSparsityMetric(precision=precision, bram_width=bram_width, target_resource="DSP")
+    assert metric.c == expected_c
+
+
+def test_fpga_handles_1d_weight():
+    """1D bias vector reshapes to (1, N) and works. Was crashing before fix."""
+    metric = FPGAAwareSparsityMetric(rf=2, target_resource="DSP", epsilon=1e-3)
+    weight = ops.ones((8,), dtype="float32")
+    result = metric(weight)
+    assert ops.abs(result) < 1e-5
+
+
+def test_fpga_dtype_propagates_for_float64():
+    """float64 weight returns float64 scalar (not hardcoded float32)."""
+    metric = FPGAAwareSparsityMetric(rf=2, target_resource="DSP", epsilon=1e-3)
+    weight = ops.cast(ops.zeros((4, 8)), "float64")
+    result = metric(weight)
+    assert "float64" in str(result.dtype)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"target_resource": "LUT"},          # invalid resource
+        {"precision": 128, "bram_width": 16},  # c=0 (precision > 2*bram_width)
+        {"rf": 0},                            # rf must be >= 1
+    ],
+)
+def test_fpga_invalid_kwargs_raise(kwargs):
+    with pytest.raises(AssertionError):
+        FPGAAwareSparsityMetric(**kwargs)
+
+
+# PACAPatternMetric
+
+
+def test_paca_returns_zero_for_non_4d():
+    """Dense (2D) weight -> PACA returns 0.0 without crashing."""
+    metric = PACAPatternMetric()
+    weight = ops.convert_to_tensor(np.random.rand(8, 4).astype(np.float32))
+    result = metric(weight)
+    assert ops.abs(result) < 1e-6
+
+
+def test_paca_dominant_patterns_lazy_caching():
+    """dominant_patterns is None until first __call__, then cached across calls."""
+    metric = PACAPatternMetric(num_patterns_to_keep=4, beta=0.75)
+    weight = _make_conv_weight()
+    assert metric.dominant_patterns is None
+
+    _ = metric(weight)
+    first = metric.dominant_patterns
+    assert first is not None
+
+    _ = metric(weight)
+    assert metric.dominant_patterns is first  # not recomputed
+
+
+def test_paca_get_projection_mask_shape_and_binary():
+    """Projection mask matches weight shape and contains only 0s and 1s."""
+    metric = PACAPatternMetric(num_patterns_to_keep=4, beta=0.75)
+    weight = _make_conv_weight()
+    _ = metric(weight)  # populate dominant_patterns
+    mask = metric.get_projection_mask(weight)
+    assert tuple(ops.shape(mask)) == tuple(ops.shape(weight))
+    mask_np = ops.convert_to_numpy(mask)
+    assert set(np.unique(mask_np).tolist()).issubset({0, 1})
+
+
+@pytest.mark.parametrize("distance_metric", ["hamming", "valued_hamming", "cosine"])
+def test_paca_all_distance_metrics(distance_metric):
+    """Each supported distance metric produces a finite scalar."""
+    metric = PACAPatternMetric(num_patterns_to_keep=4, beta=0.75, distance_metric=distance_metric)
+    weight = _make_conv_weight()
+    val = float(ops.convert_to_numpy(metric(weight)))
+    assert math.isfinite(val)
+
+
+def test_paca_get_projection_mask_returns_identity_when_no_patterns():
+    """If __call__ was never invoked, get_projection_mask returns ones_like (no-op)."""
+    metric = PACAPatternMetric(num_patterns_to_keep=4, beta=0.75)
+    weight = _make_conv_weight()
+    mask = metric.get_projection_mask(weight)
+    assert tuple(ops.shape(mask)) == tuple(ops.shape(weight))
+    mask_np = ops.convert_to_numpy(mask)
+    np.testing.assert_array_equal(mask_np, np.ones_like(mask_np))
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"num_patterns_to_keep": 0},
+        {"beta": 1.5},
+        {"distance_metric": "manhattan"},
+    ],
+)
+def test_paca_invalid_kwargs_raise(kwargs):
+    with pytest.raises(AssertionError):
+        PACAPatternMetric(**kwargs)
+
+
+# Pattern helpers
+
+
+def test_patterns_helper_kernels_and_patterns():
+    """_get_kernels_and_patterns flattens correctly and binarizes by epsilon."""
+    weight = ops.convert_to_tensor(
+        np.array([[[[1.0, 0.0], [0.0, 1.0]]]], dtype=np.float32)
+    )  # shape (1, 1, 2, 2)
+    kernels, all_patterns, _ = patterns._get_kernels_and_patterns(weight, src="OIHW", epsilon=0.5)
+    assert tuple(ops.shape(kernels)) == (1, 4)
+    pattern_np = ops.convert_to_numpy(all_patterns)
+    np.testing.assert_array_equal(pattern_np, np.array([[1, 0, 0, 1]], dtype=np.uint8))
+
+
+# MDMM integration through the registry
+
+
+def _conv_weight_for_mdmm():
+    rng = np.random.default_rng(0)
+    arr = rng.standard_normal((4, 4, 3, 3)).astype(np.float32)
+    arr[:2] = 0.0  # zero half the kernels for a non-trivial mask
+    return ops.convert_to_tensor(arr)
+
+
+def test_mdmm_fpga_full_phase_cycle(base_config):
+    """MDMM with FPGAAwareSparsity runs through pretraining/active/finetuning."""
+    base_config["pruning_parameters"]["metric_type"] = "FPGAAwareSparsity"
+    base_config["pruning_parameters"]["precision"] = 16
+    base_config["pruning_parameters"]["target_resource"] = "DSP"
+    base_config["pruning_parameters"]["bram_width"] = 36
+    base_config["pruning_parameters"]["rf"] = 2
+
+    weight = _conv_weight_for_mdmm()
+    mdmm = MDMM(base_config, "conv")
+    mdmm.build(weight.shape)
+
+    out = mdmm(weight)  # pretraining
+    assert ops.all(ops.equal(out, weight))
+    assert mdmm.losses[-1] < 1e-8
+
+    mdmm.post_pre_train_function()
+    _ = mdmm(weight)  # active
+
+    mdmm.pre_finetune_function()
+    _ = mdmm(weight)  # finetuning
+    assert mdmm.losses[-1] < 1e-8
+
+
+def test_mdmm_paca_forces_equality_constraint(base_config):
+    """PACA always pairs with EqualityConstraint(target=0), even if config says GEQ."""
+    base_config["pruning_parameters"]["metric_type"] = "PACAPatternSparsity"
+    base_config["pruning_parameters"]["constraint_type"] = "GreaterThanOrEqual"  # ignored
+    base_config["pruning_parameters"]["target_value"] = 99.0  # ignored
+    base_config["pruning_parameters"]["num_patterns_to_keep"] = 4
+    base_config["pruning_parameters"]["beta"] = 0.85
+    base_config["pruning_parameters"]["distance_metric"] = "cosine"
+
+    weight = _conv_weight_for_mdmm()
+    mdmm = MDMM(base_config, "conv")
+    mdmm.build(weight.shape)
+
+    from pquant.pruning_methods.constraint_functions import EqualityConstraint
+    assert isinstance(mdmm.constraint_layer, EqualityConstraint)
+    assert mdmm.constraint_layer.target_value == 0.0
+
+
+def test_mdmm_paca_full_phase_cycle(base_config):
+    """MDMM with PACA: dominant_patterns set in pretraining, finetuning uses projection mask."""
+    base_config["pruning_parameters"]["metric_type"] = "PACAPatternSparsity"
+    base_config["pruning_parameters"]["num_patterns_to_keep"] = 4
+    base_config["pruning_parameters"]["beta"] = 0.85
+    base_config["pruning_parameters"]["distance_metric"] = "cosine"
+
+    weight = _conv_weight_for_mdmm()
+    mdmm = MDMM(base_config, "conv")
+    mdmm.build(weight.shape)
+
+    out = mdmm(weight)  # pretraining
+    assert ops.all(ops.equal(out, weight))
+    assert mdmm.constraint_layer.metric_fn.dominant_patterns is not None
+
+    mdmm.post_pre_train_function()
+    _ = mdmm(weight)  # active
+
+    mdmm.pre_finetune_function()
+    out = mdmm(weight)  # finetuning -> output is weight * binary_mask
+    out_np = ops.convert_to_numpy(out)
+    weight_np = ops.convert_to_numpy(weight)
+    is_zero_or_equal = np.logical_or(np.isclose(out_np, 0.0), np.isclose(out_np, weight_np))
+    assert is_zero_or_equal.all()
+
+
+# Pydantic schema validation
+
+
+def test_pydantic_accepts_new_metric_types():
+    """Both new metric_types validate with their associated parameters."""
+    from pquant.data_models.pruning_model import MDMMPruningModel
+    fpga = MDMMPruningModel(
+        metric_type="FPGAAwareSparsity",
+        precision=16,
+        target_resource="DSP",
+        bram_width=36,
+    )
+    assert fpga.metric_type == "FPGAAwareSparsity"
+    assert fpga.precision == 16
+
+    paca = MDMMPruningModel(
+        metric_type="PACAPatternSparsity",
+        num_patterns_to_keep=8,
+        beta=0.9,
+        distance_metric="hamming",
+    )
+    assert paca.metric_type == "PACAPatternSparsity"
+    assert paca.beta == 0.9
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"metric_type": "BogusMetric"},
+        {"target_resource": "LUT"},
+        {"distance_metric": "manhattan"},
+    ],
+)
+def test_pydantic_rejects_invalid_values(kwargs):
+    from pydantic import ValidationError
+    from pquant.data_models.pruning_model import MDMMPruningModel
+    with pytest.raises(ValidationError):
+        MDMMPruningModel(**kwargs)


### PR DESCRIPTION
Adds tests for the existing MDMM pruning method and integrates the hardware-aware metric functions (`FPGAAwareSparsityMetric` and `PACAPatternMetric`) that were lost during intermediate branch merging.                                             
  
Also fixes a `float32/int32` dtype bug in `get_layer_sparsity` on the TensorFlow backend.

  ### Supported backends
  - `KERAS_BACKEND=tensorflow`                                
  - `KERAS_BACKEND=torch`                                 
                                                              
  ### Test files
  - `pytest tests/test_mdmm.py tests/test_mdmm_metrics.py`