### PR TITLE
fix keras mha sep-conv bug, fix torch hgq hls4ml conversion bug

### DIFF
--- a/src/pquant/core/keras/activations.py
+++ b/src/pquant/core/keras/activations.py
@@ -340,9 +340,18 @@ class PQSoftmax(keras.layers.Layer):
 
         self.input_quantizer = _data_quantizer(self.k_input, self.i_input, self.f_input)
         self.output_quantizer = _data_quantizer(self.k_output, self.i_output, self.f_output)
-        if self.use_hgq:
-            self.input_quantizer.build(input_shape)
-            self.output_quantizer.build(input_shape)
+        accum_shape = tuple(1 if i in self.axes else s for i, s in enumerate(input_shape))
+        self.input_quantizer.build(input_shape)
+        self.output_quantizer.build(input_shape)
+        if not self.exp_table.built:
+            self.exp_table.build(input_shape)
+        if not self.inv_table.built:
+            self.inv_table.build(accum_shape)
+        for table, shape in ((self.exp_table, input_shape), (self.inv_table, accum_shape)):
+            if table.quantize_input and not table.input_quantizer.built:
+                table.input_quantizer.build(shape)
+            if table.quantize_output and not table.output_quantizer.built:
+                table.output_quantizer.build(shape)
         super().build(input_shape)
 
     def get_input_quantization_bits(self):

--- a/src/pquant/core/keras/layers.py
+++ b/src/pquant/core/keras/layers.py
@@ -846,6 +846,16 @@ class PQSeparableConv2d(Layer):
         self.depthwise_conv._rewind_weights()
         self.pointwise_conv._rewind_weights()
 
+    def build(self, input_shape):
+        self.depthwise_conv.build(input_shape)
+        intermediate_shape = self.depthwise_conv.compute_output_shape(input_shape)
+        self.pointwise_conv.build(intermediate_shape)
+        super().build(input_shape)
+
+    def compute_output_shape(self, input_shape):
+        intermediate_shape = self.depthwise_conv.compute_output_shape(input_shape)
+        return self.pointwise_conv.compute_output_shape(intermediate_shape)
+
     def call(self, x, training=None):
         x = self.depthwise_conv(x, training=training)
         x = self.pointwise_conv(x, training=training)
@@ -1811,6 +1821,42 @@ class PQMultiheadAttention(keras.layers.Layer):
             return ops.convert_to_tensor(0.0)
         return ops.convert_to_tensor(self.hgq_beta * self.attention_ebops() + self.softmax.hgq_loss())
 
+    def build(self, input_shape):
+        if isinstance(input_shape, (list, tuple)) and isinstance(input_shape[0], (list, tuple)):
+            if len(input_shape) == 3:
+                query_shape, key_shape, value_shape = input_shape
+            elif len(input_shape) == 2:
+                query_shape, key_shape = input_shape
+                value_shape = key_shape
+            else:
+                query_shape = key_shape = value_shape = input_shape[0]
+        else:
+            query_shape = key_shape = value_shape = input_shape
+        if not self.q_proj.built:
+            self.q_proj.build(query_shape)
+        if not self.k_proj.built:
+            self.k_proj.build(key_shape)
+        if not self.v_proj.built:
+            self.v_proj.build(value_shape)
+        scores_shape = (query_shape[0], self.num_heads, query_shape[1], key_shape[1])
+        if not self.softmax.built:
+            self.softmax.build(scores_shape)
+        if not self.out_proj.built:
+            self.out_proj.build((query_shape[0], query_shape[1], self.embed_dim))
+        super().build(input_shape)
+
+    def compute_output_spec(self, inputs, training=None, key_padding_mask=None, attn_mask=None, need_weights=True):
+        if isinstance(inputs, (list, tuple)):
+            query = inputs[0]
+            key = inputs[1] if len(inputs) > 1 else inputs[0]
+        else:
+            query = key = inputs
+        out = keras.KerasTensor((query.shape[0], query.shape[1], self.embed_dim), dtype=self.compute_dtype)
+        if need_weights:
+            attn = keras.KerasTensor((query.shape[0], query.shape[1], key.shape[1]), dtype=self.compute_dtype)
+            return out, attn
+        return out, None
+
     def call(
         self,
         inputs,
@@ -2222,10 +2268,12 @@ def add_compression_layers(model, config, input_shape=None):
             new_layer.pointwise_conv.set_enable_pruning(enable_pruning_pointwise)
             _build_pruning_layer_from_kernel(new_layer.depthwise_conv, layer.depthwise_kernel)
             _build_pruning_layer_from_kernel(new_layer.pointwise_conv, layer.pointwise_kernel)
-            new_layer.depthwise_conv.build(x.shape)
-            y = new_layer.depthwise_conv(x).shape
-            new_layer.pointwise_conv.build(y)
+            new_layer.build(x.shape)
             x = new_layer(x)
+            new_layer.depthwise_conv._kernel.assign(layer.depthwise_kernel)
+            new_layer.pointwise_conv._kernel.assign(layer.pointwise_kernel)
+            if layer.use_bias:
+                new_layer.pointwise_conv._bias.assign(layer.bias)
             act = _check_activation(layer, config)
         elif isinstance(layer, Conv1D):
             new_layer = PQConv1d(

--- a/src/pquant/core/torch/quantizer.py
+++ b/src/pquant/core/torch/quantizer.py
@@ -30,12 +30,13 @@ class Quantizer(nn.Module):
         self.is_data = is_data
         self.dynamic_data = dynamic_data
         self.granularity = QuantizationGranularity(granularity).value
-        if not self.use_hgq:
-            param_shape = () if is_data else self.compute_weight_param_shape(shape)
-            self.k = torch.nn.Parameter(torch.full(param_shape, float(k)), requires_grad=False)
-            self.i = torch.nn.Parameter(torch.full(param_shape, float(i)), requires_grad=False)
-            self.f = torch.nn.Parameter(torch.full(param_shape, float(f)), requires_grad=False)
-            self.b = torch.nn.Parameter(torch.full(param_shape, float(i + k + f)), requires_grad=False)
+
+        # Params even when using HGQ, as they are used during hls4ml conversion
+        param_shape = () if (is_data or self.use_hgq) else self.compute_weight_param_shape(shape)
+        self.k = torch.nn.Parameter(torch.full(param_shape, float(k)), requires_grad=False)
+        self.i = torch.nn.Parameter(torch.full(param_shape, float(i)), requires_grad=False)
+        self.f = torch.nn.Parameter(torch.full(param_shape, float(f)), requires_grad=False)
+        self.b = torch.nn.Parameter(torch.full(param_shape, float(i + k + f)), requires_grad=False)
         self.quantizer = create_quantizer(
             k,
             i,
@@ -63,6 +64,16 @@ class Quantizer(nn.Module):
         else:
             b = self.i + self.f + self.k
             return torch.ones(shape).to(b.device) * b
+
+    def _sync_hgq_mirror_bits(self):
+        if not self.quantizer.built:
+            return
+        with torch.no_grad():
+            k, i, f = self.quantizer.k.detach(), self.quantizer.i.detach(), self.quantizer.f.detach()
+            self.k.data = k.clone()
+            self.i.data = i.clone()
+            self.f.data = f.clone()
+            self.b.data = k + i + f
 
     def set_quantization_bits(self, i, f):
         if self.use_hgq:
@@ -146,6 +157,7 @@ class Quantizer(nn.Module):
                 self.quantizer._f.data.clamp_(self.quantizer.f_min, self.quantizer.f_max)
                 if self.quantizer.overflow_mode != "WRAP":
                     self.quantizer._i.data.clamp_(self.quantizer.i_min, self.quantizer.i_max)
+            self._sync_hgq_mirror_bits()
             self.final_compression_done.fill_(True)
             return
         _, i, f = self.get_quantization_bits()

--- a/tests/test_keras_compression_layers.py
+++ b/tests/test_keras_compression_layers.py
@@ -302,8 +302,7 @@ def test_separable_conv2d_call(config_pdp, conv2d_input):
         layer_to_replace.pointwise_constraint,
         layer_to_replace.bias_constraint,
     )
-    layer.depthwise_conv.build(conv2d_input.shape)
-    layer.pointwise_conv.build(conv2d_input.shape)
+    layer.build(conv2d_input.shape)
     layer.depthwise_conv._kernel.assign(layer_to_replace.depthwise_kernel)
     layer.pointwise_conv._kernel.assign(layer_to_replace.pointwise_kernel)
 
@@ -317,8 +316,14 @@ def test_separable_conv2d_add_remove_layers(config_pdp, conv2d_input):
     inputs = keras.Input(shape=conv2d_input.shape[1:])
     out = SeparableConv2D(OUT_FEATURES, KERNEL_SIZE, use_bias=False, padding="same")(inputs)
     model = keras.Model(inputs=inputs, outputs=out, name="test_conv2d")
+    depthwise_kernel = ops.copy(model.layers[1].depthwise_kernel)
+    pointwise_kernel = ops.copy(model.layers[1].pointwise_kernel)
     model = add_compression_layers(model, config_pdp, conv2d_input.shape)
     model(conv2d_input)
+
+    # The original layer's weights must survive the replacement.
+    assert ops.all(ops.equal(model.layers[1].depthwise_conv._kernel, depthwise_kernel))
+    assert ops.all(ops.equal(model.layers[1].pointwise_conv._kernel, pointwise_kernel))
 
     post_pretrain_functions(model, config_pdp)
     pre_finetune_functions(model)


### PR DESCRIPTION
keras pqmultiheadattention and sep-conv had some issues, only surfaced after the dst loss calculation fix. Torch HGQ quantizer conversion to hls4ml didn't work as an important section related to that had been removed earlier. 